### PR TITLE
Small changes to DSL.

### DIFF
--- a/lib/ja_serializer/builder/attribute.ex
+++ b/lib/ja_serializer/builder/attribute.ex
@@ -4,11 +4,8 @@ defmodule JaSerializer.Builder.Attribute do
   defstruct [:key, :value]
 
   def build(%{model: model, serializer: serializer, conn: conn}) do
-    Enum.map serializer.__attributes, fn(attr) ->
-      %__MODULE__{
-        key:   attr,
-        value: apply(serializer, attr, [model, conn])
-      }
-    end
+    Enum.map apply(serializer,:attributes, [model, conn]), &do_build/1
   end
+
+  def do_build({key, value}), do: %__MODULE__{key: key, value: value}
 end

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -36,7 +36,7 @@ defmodule JaSerializer.Builder.Relationship do
   defp type_from_opts(opts) do
     case {opts[:type], opts[:include]} do
       {nil, nil}        -> nil
-      {nil, serializer} -> apply(serializer, :__type_key, [])
+      {nil, serializer} -> apply(serializer, :type, [])
       {type, _}         -> type
     end
   end

--- a/lib/ja_serializer/builder/resource_object.ex
+++ b/lib/ja_serializer/builder/resource_object.ex
@@ -18,7 +18,7 @@ defmodule JaSerializer.Builder.ResourceObject do
   def build(%{serializer: serializer} = context) do
     %__MODULE__{
       id:            apply(serializer, :id, [context.model, context.conn]),
-      type:          serializer.__type_key,
+      type:          serializer.type,
       model:         context.model,
       attributes:    Attribute.build(context),
       relationships: Relationship.build(context),

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -4,32 +4,29 @@ defmodule JaSerializer.Builder.IncludedTest do
   defmodule ArticleSerializer do
     use JaSerializer
 
-    serialize "articles" do
-      attributes [:title]
-      has_many :comments,
-        include: JaSerializer.Builder.IncludedTest.CommentSerializer
-      has_one :author,
-        include: JaSerializer.Builder.IncludedTest.PersonSerializer
-    end
+    def type, do: "articles"
+    attributes [:title]
+    has_many :comments,
+      include: JaSerializer.Builder.IncludedTest.CommentSerializer
+    has_one :author,
+      include: JaSerializer.Builder.IncludedTest.PersonSerializer
   end
 
   defmodule PersonSerializer do
     use JaSerializer
-    serialize "people" do
-      attributes [:name]
-    end
+    def type, do: "people"
+    attributes [:name]
   end
 
   defmodule CommentSerializer do
     use JaSerializer
-    serialize "comments" do
-      location "/comments/:id"
-      attributes [:body]
-      has_one :author,
-        include: JaSerializer.Builder.IncludedTest.PersonSerializer
-      has_many :comments,
-        include: JaSerializer.Builder.IncludedTest.CommentSerializer
-    end
+    def type, do: "comments"
+    location "/comments/:id"
+    attributes [:body]
+    has_one :author,
+      include: JaSerializer.Builder.IncludedTest.PersonSerializer
+    has_many :comments,
+      include: JaSerializer.Builder.IncludedTest.CommentSerializer
   end
 
   test "multiple levels of includes are respected" do

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -69,32 +69,29 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     alias JaSerializer.JsonApiSpec.CompoundDocumentTest.PersonSerializer
     alias JaSerializer.JsonApiSpec.CompoundDocumentTest.CommentSerializer
 
-    serialize "articles" do
-      location "/articles/:id"
-      attributes [:title]
-      has_many :comments,
-        link: "/articles/:id/comments",
-        include: CommentSerializer
-      has_one :author,
-        link: "/articles/:id/author",
-        include: PersonSerializer
-    end
+    def type, do: "articles"
+    location "/articles/:id"
+    attributes [:title]
+    has_many :comments,
+      link: "/articles/:id/comments",
+      include: CommentSerializer
+    has_one :author,
+      link: "/articles/:id/author",
+      include: PersonSerializer
   end
 
   defmodule PersonSerializer do
     use JaSerializer
-    serialize "people" do
-      location "/people/:id"
-      attributes [:first_name, :last_name, :twitter]
-    end
+    def type, do: "people"
+    location "/people/:id"
+    attributes [:first_name, :last_name, :twitter]
   end
 
   defmodule CommentSerializer do
     use JaSerializer
-    serialize "comments" do
-      location "/comments/:id"
-      attributes [:body]
-    end
+    def type, do: "comments"
+    location "/comments/:id"
+    attributes [:body]
   end
 
   test "it serializes properly" do

--- a/test/ja_serializer/json_api_spec/resource_object_test.exs
+++ b/test/ja_serializer/json_api_spec/resource_object_test.exs
@@ -27,12 +27,11 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
   defmodule ArticleSerializer do
     use JaSerializer
 
-    serialize "articles" do
-      attributes [:title]
-      has_one :author,
-        link: "/articles/:id/author",
-        type: "people"
-    end
+    def type, do: "articles"
+    attributes [:title]
+    has_one :author,
+      link: "/articles/:id/author",
+      type: "people"
   end
 
   test "it serializes properly" do

--- a/test/ja_serializer/serializer_test.exs
+++ b/test/ja_serializer/serializer_test.exs
@@ -3,27 +3,47 @@ defmodule JaSerializer.SerializerTest do
 
   defmodule ArticleSerializer do
     use JaSerializer.Serializer
-    attributes [:title]
+    attributes [:title, :body]
   end
 
-  defmodule AuthorView do
+  defmodule ArticleView do
     use JaSerializer.Serializer
-    attributes [:name]
+    attributes [:title, :body]
+
+    def attributes(model, conn) do
+      super(model, conn) |> Dict.take([:title])
+    end
   end
 
-  defmodule CustomJsonMaker do
+  defmodule CustomArticle do
     use JaSerializer.Serializer
-    def type, do: "comment"
-    attributes [:name]
+
+    def type, do: "article"
+
+    def attributes(model, _conn) do
+      Map.take(model, [:body])
+    end
   end
 
   @serializer ArticleSerializer
-  @view AuthorView
-  @custom CustomJsonMaker
+  @view ArticleView
+  @custom CustomArticle
 
   test "it should determine the type" do
     assert @serializer.type == "article"
-    assert @view.type == "author"
-    assert @custom.type == "comment"
+    assert @view.type == "article"
+    assert @custom.type == "article"
+  end
+
+  test "it should return the attributes" do
+    model = %TestModel.Article{title: "test", body: "test"}
+
+    assert @serializer.attributes(model, %{}) == %{
+      title: "test",
+      body: "test"
+    }
+
+    assert @view.attributes(model, %{}) == %{title: "test"}
+    assert @custom.attributes(model, %{}) == %{body: "test"}
   end
 end

--- a/test/ja_serializer/serializer_test.exs
+++ b/test/ja_serializer/serializer_test.exs
@@ -1,0 +1,29 @@
+defmodule JaSerializer.SerializerTest do
+  use ExUnit.Case
+
+  defmodule ArticleSerializer do
+    use JaSerializer.Serializer
+    attributes [:title]
+  end
+
+  defmodule AuthorView do
+    use JaSerializer.Serializer
+    attributes [:name]
+  end
+
+  defmodule CustomJsonMaker do
+    use JaSerializer.Serializer
+    def type, do: "comment"
+    attributes [:name]
+  end
+
+  @serializer ArticleSerializer
+  @view AuthorView
+  @custom CustomJsonMaker
+
+  test "it should determine the type" do
+    assert @serializer.type == "article"
+    assert @view.type == "author"
+    assert @custom.type == "comment"
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,7 +6,7 @@ defmodule TestModel.Person do
 end
 
 defmodule TestModel.Article do
-  defstruct [:id, :title, :author, :comments]
+  defstruct [:id, :title, :author, :comments, :body]
 end
 
 defmodule TestModel.Comment do


### PR DESCRIPTION
* `type/0` callback now expected to return serializer type.
* Default `type/0` implementation guesses at type based on module name.
* `serializer/2` macro deprecated in favor of `type/1`.
* `id/2` callback added and documented, expected to return id.
* `attributes/2` callback added, expected to return actual map of attributes to be returned.
* Default `attributes/2` implementation finds values as populated by `attributes/1`.

//cc @beerlington Some of the changes we talked about are here.