### PR TITLE
Implement pagination links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ model
 |> Poison.encode!
 ```
 
+#### Pagination Usage
+
+Pass a `page` map with keys `page_number`, `total_pages` and `page_size` to the format method.
+
+```elixir
+model
+|> MyApp.ArticleSerializer.format(conn, %{page: %{page_number: 3, total_pages: 5, page_size: 10}})
+|> Poison.encode!
+```
+
+Or you could use the [scrivener library](https://github.com/drewolson/scrivener) and pass the page
+as a parameter
+
+```elixir
+page = MyApp.Person |> MyApp.Repo.paginate(page: 2, page_size: 5)
+MyApp.ArticleSerializer.format(page.entries, conn, page)
+|> Poison.encode!
+```
+
 ### Relax Usage
 
 See [Relax](https://github.com/AgilionApps/relax) documentation for building
@@ -83,6 +102,27 @@ defmodule PhoenixExample.ArticlesView do
   attributes [:title]
   #has_many, etc.
 end
+```
+
+#### Pagination Usage
+
+Pass a page `map` with keys `page_number`, `total_pages` and `page_size` in a `opts` map.
+
+```elixir
+  def index(conn, _params) do
+    page = %{page_number: 3, total_pages: 5, page_size: 10}
+    render conn, model: PhoenixExample.Repo.all(PhoenixExample.Article), opts: %{page: page}
+  end
+```
+
+Or you could use the [scrivener library](https://github.com/drewolson/scrivener) and pass the page
+as a parameter
+
+```elixir
+  def index(conn, _params) do
+    page = MyApp.Article |> MyApp.Repo.paginate(page: 2, page_size: 5)
+    render conn, model: page.entries, opts: %{page: page}
+  end
 ```
 
 To use the Phoenix `accepts` plug you must configure Plug to handle the
@@ -165,5 +205,5 @@ end
 
 ## License
 
-JaSerializer source code is released under Apache 2 License. Check LICENSE 
+JaSerializer source code is released under Apache 2 License. Check LICENSE
 file for more information.

--- a/lib/ja_serializer/builder/pagination_links.ex
+++ b/lib/ja_serializer/builder/pagination_links.ex
@@ -1,0 +1,56 @@
+defmodule JaSerializer.Builder.PaginationLinks do
+
+  @moduledoc """
+  To build pagination links part of the data attr in a jsonapi spec.
+
+    iex> page = %Page{page_number: 3, total_pages: 5, page_size: 10}
+    iex> PaginationLinks.build("/api/posts", page)
+        [self: "/api/posts/page=3&page_size=10",
+        first: "/api/posts/page=1&page_size=10",
+        prev: "/api/posts/page=2&page_size=10",
+        last: "/api/posts/page=5&page_size=10",
+        next: "/api/posts/page=4&page_size=10"]
+    iex2>
+  """
+
+  @first_page 1
+
+  @spec build(String.t, map) :: [key: String.t]
+  def build(url, page) do
+    {[], page}
+    |> current_page
+    |> previous_pages
+    |> next_pages
+    |> create_urls(url)
+  end
+
+  defp current_page({list, page}) do
+    {list ++ [self: page.page_number], page}
+  end
+
+  defp previous_pages({list, page}) do
+    if page.page_number == 1 do
+      {list, page}
+    else
+      prev = page.page_number - @first_page
+      {list ++ [first: @first_page, prev: prev], page}
+    end
+  end
+
+  defp next_pages({list, page}) do
+    if page.page_number == page.total_pages do
+      {list, page}
+    else
+      next = page.page_number + @first_page
+      {list ++ [last: page.total_pages, next: next], page}
+    end
+  end
+
+  defp create_urls({list, page}, url) do
+    Enum.map(list, fn {key, val} ->
+      params = %{page: val, page_size: page.page_size} |> URI.encode_query
+      final_url = "#{url}/#{params}"
+      {key, final_url}
+    end)
+  end
+end

--- a/lib/ja_serializer/builder/top_level.ex
+++ b/lib/ja_serializer/builder/top_level.ex
@@ -3,6 +3,8 @@ defmodule JaSerializer.Builder.TopLevel do
 
   alias JaSerializer.Builder.ResourceObject
   alias JaSerializer.Builder.Included
+  alias JaSerializer.Builder.Link
+  alias JaSerializer.Builder.PaginationLinks
 
   defstruct [:data, :errors, :included, :meta, :links, :jsonapi]
 
@@ -15,9 +17,32 @@ defmodule JaSerializer.Builder.TopLevel do
     |> add_links(context)
   end
 
-  #TODO Add links for pagination etc
+  def add_links(tl, %{opts: %{page: _}} = context) do
+    data = tl.data
+    if is_list(data) do
+      links = data
+              |> hd
+              |> find_index_url
+              |> map_links(data, context)
+      Map.put(tl, :links, links)
+    else
+      tl
+    end
+  end
+
   def add_links(tl, _context), do: tl
 
   #TODO: Add meta
   def add_meta(tl, _context), do: tl
+
+  defp find_index_url(data) do
+    root_link = data.links |> hd
+    String.replace(root_link.href, ~r{\/\d+/?$}, "")
+  end
+
+  defp map_links(index_url, list, context) do
+    index_url
+    |> PaginationLinks.build(context.opts.page)
+    |> Enum.map(fn({type, url}) -> Link.build(context, type, url) end)
+  end
 end

--- a/lib/ja_serializer/formatter/top_level.ex
+++ b/lib/ja_serializer/formatter/top_level.ex
@@ -4,6 +4,15 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.TopLevel do
   def format(struct) do
     %{jsonapi: %{version: "1.0"}}
     |> Map.put(:data, JaSerializer.Formatter.format(struct.data))
+    |> format_links(struct.links)
     |> Utils.put_if_present(:included, JaSerializer.Formatter.format(struct.included))
+  end
+
+  defp format_links(resource, nil), do: resource
+
+  defp format_links(resource, links) do
+    links = JaSerializer.Formatter.format(links)
+            |> Enum.into %{}
+    Map.put(resource, :links, links)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule JaSerializer.Mixfile do
     [{:inflex, "~> 1.4"},
      {:plug, "~> 1.0", optional: true},
      {:ecto, "~> 1.0", optional: true},
-     {:poison, "~> 1.4", only: :test},
+     {:poison, "~> 1.4"},
      {:earmark, "~> 0.1", only: :dev},
      {:inch_ex, "~> 0.4", only: :docs},
      {:ex_doc, "~> 0.7", only: :dev}]

--- a/test/ja_serializer/builder/pagination_links_test.exs
+++ b/test/ja_serializer/builder/pagination_links_test.exs
@@ -1,0 +1,43 @@
+defmodule JaSerializer.Builder.PaginationLinksTest do
+  use ExUnit.Case
+
+  defmodule Page do
+    defstruct [page_number: 3, total_pages: 5, page_size: 10]
+  end
+  alias JaSerializer.Builder.PaginationLinks
+
+  test "when current page is first, do not include first, prev links" do
+    links = PaginationLinks.build("/api/posts", %Page{page_number: 1})
+
+    assert Enum.sort([:self, :last, :next]) == Dict.keys(links) |> Enum.sort
+    assert [
+      "/api/posts/page=1&page_size=10",
+      "/api/posts/page=2&page_size=10",
+      "/api/posts/page=5&page_size=10"
+    ] == Dict.values(links) |> Enum.sort
+  end
+
+  test "when current page is in the middle, includes all links" do
+    links = PaginationLinks.build("/api/posts", %Page{})
+
+    assert Enum.sort([:self, :first, :prev, :last, :next]) == Dict.keys(links) |> Enum.sort
+    assert [
+      "/api/posts/page=1&page_size=10",
+      "/api/posts/page=2&page_size=10",
+      "/api/posts/page=3&page_size=10",
+      "/api/posts/page=4&page_size=10",
+      "/api/posts/page=5&page_size=10"
+    ] == Dict.values(links) |> Enum.sort
+  end
+
+  test "when current page is the last, do not include last, next links" do
+    links = PaginationLinks.build("/api/posts", %Page{page_number: 5})
+
+    assert Enum.sort([:self, :first, :prev]) == Dict.keys(links) |> Enum.sort
+    assert [
+      "/api/posts/page=1&page_size=10",
+      "/api/posts/page=4&page_size=10",
+      "/api/posts/page=5&page_size=10"
+    ] == Dict.values(links) |> Enum.sort
+  end
+end

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -11,7 +11,7 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
         "title": "JSON API paints my bikeshed!"
       },
       "links": {
-        "self": "/articles/1"
+       "self": "/articles/1"
       },
       "relationships": {
         "author": {
@@ -31,6 +31,13 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
         }
       }
     }],
+    "links": {
+       "first": "/articles/page=1&page_size=10",
+       "last": "/articles/page=5&page_size=10",
+       "next": "/articles/page=4&page_size=10",
+       "prev": "/articles/page=2&page_size=10",
+       "self": "/articles/page=3&page_size=10"
+     },
     "included": [{
       "type": "people",
       "id": "9",
@@ -94,6 +101,10 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     attributes [:body]
   end
 
+  defmodule Page do
+    defstruct [page_number: 3, total_pages: 5, page_size: 10]
+  end
+
   test "it serializes properly" do
     author = %TestModel.Person{
       id: 9,
@@ -120,14 +131,16 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     }
 
     results = [article]
-              |> ArticleSerializer.format
+              |> ArticleSerializer.format(%{}, %{page: %Page{}})
               |> Poison.encode!
               |> Poison.decode!(keys: :atoms)
 
     expected = Poison.decode!(@expected, keys: :atoms)
 
-    assert results[:data] == expected[:data]
+    assert results[:links] == expected[:links]
     assert results[:included] == expected[:included]
+    assert results[:data][:attributes] == expected[:data][:attributes]
+    assert results[:data] == expected[:data]
     assert results == expected
   end
 end

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -4,6 +4,7 @@ defmodule JaSerializer.PhoenixViewTest do
   defmodule PhoenixExample.ArticleView do
     use JaSerializer.PhoenixView
     attributes [:title]
+    location "/api/articles"
   end
 
   @view PhoenixExample.ArticleView
@@ -12,6 +13,10 @@ defmodule JaSerializer.PhoenixViewTest do
     m1 = %TestModel.Article{id: 1, title: "article one"}
     m2 = %TestModel.Article{id: 2, title: "article two"}
     {:ok, m1: m1, m2: m2}
+  end
+
+  defmodule Page do
+    defstruct [page_number: 3, total_pages: 5, page_size: 10]
   end
 
   test "render conn, index.json, model: model", c do
@@ -26,6 +31,14 @@ defmodule JaSerializer.PhoenixViewTest do
     assert [a1, _a2] = json[:data]
     assert Dict.has_key?(a1, :id)
     assert Dict.has_key?(a1, :attributes)
+  end
+
+  test "render conn, index.json, model: model with pagination", c do
+    json = @view.render("index.json", conn: %{}, model: [c[:m1], c[:m2]], opts: %{page: %Page{}})
+    assert [a1, _a2] = json[:data]
+    assert Dict.has_key?(a1, :id)
+    assert Dict.has_key?(a1, :attributes)
+    assert Dict.has_key?(json, :links)
   end
 
   test "render conn, show.json, data: model", c do


### PR DESCRIPTION
As per the [json api spec on pagination links](http://jsonapi.org/format/#fetching-pagination), make a top level `links` object with keys

- self
- first
- last
- prev
- next


(P.S I could not run tests without removing `only: :test` option in `mix.exs` file for `Poison` library. )
