### PR TITLE
Fix empty relationships

### DIFF
--- a/lib/ja_serializer/builder/resource_identifier.ex
+++ b/lib/ja_serializer/builder/resource_identifier.ex
@@ -7,6 +7,8 @@ defmodule JaSerializer.Builder.ResourceIdentifier do
     serializer
     |> apply(name, [context.model, context.conn])
     |> case do
+      [] -> [:empty_relationship]
+      nil -> :empty_relationship
       many when is_list(many) -> Enum.map(many, &build(&1, type))
       one -> build(one, type)
     end

--- a/lib/ja_serializer/formatter/relationship.ex
+++ b/lib/ja_serializer/formatter/relationship.ex
@@ -3,7 +3,7 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.Relationship do
 
   def format(rel) do
     json = %{}
-    |> Utils.put_if_present(:data, JaSerializer.Formatter.format(rel.data))
+    |> Utils.add_data_if_present(JaSerializer.Formatter.format(rel.data))
     |> Utils.put_if_present(:links, Utils.array_to_hash(rel.links))
     {Utils.format_key(rel.name), json}
   end

--- a/lib/ja_serializer/formatter/utils.ex
+++ b/lib/ja_serializer/formatter/utils.ex
@@ -9,6 +9,11 @@ defmodule JaSerializer.Formatter.Utils do
   def put_if_present(dict, key, val), do: Dict.put(dict, key, val)
 
   @doc false
+  def add_data_if_present(dict, :empty_relationship), do: Dict.put(dict, :data, nil)
+  def add_data_if_present(dict, [:empty_relationship]), do: Dict.put(dict, :data, [])
+  def add_data_if_present(dict, val), do: put_if_present(dict, :data, val)
+
+  @doc false
   def array_to_hash(nil),   do: nil
   def array_to_hash([nil]), do: nil
   def array_to_hash(structs) do

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -28,6 +28,18 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
             { "type": "comments", "id": "5" },
             { "type": "comments", "id": "12" }
           ]
+        },
+        "likes": {
+          "links": {
+            "related": "/articles/1/likes"
+          },
+          "data": []
+        },
+        "excerpt": {
+          "links": {
+            "related": "/articles/1/excerpt"
+          },
+          "data": null
         }
       }
     }],
@@ -75,6 +87,8 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     use JaSerializer
     alias JaSerializer.JsonApiSpec.CompoundDocumentTest.PersonSerializer
     alias JaSerializer.JsonApiSpec.CompoundDocumentTest.CommentSerializer
+    alias JaSerializer.JsonApiSpec.CompoundDocumentTest.LikeSerializer
+    alias JaSerializer.JsonApiSpec.CompoundDocumentTest.ExcerptSerializer
 
     def type, do: "articles"
     location "/articles/:id"
@@ -85,6 +99,12 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     has_one :author,
       link: "/articles/:id/author",
       include: PersonSerializer
+    has_many :likes,
+      link: "/articles/:id/likes",
+      include: LikeSerializer
+    has_one :excerpt,
+      link: "/articles/:id/excerpt",
+      include: ExcerptSerializer
   end
 
   defmodule PersonSerializer do
@@ -98,6 +118,19 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     use JaSerializer
     def type, do: "comments"
     location "/comments/:id"
+    attributes [:body]
+  end
+
+  defmodule LikeSerializer do
+    use JaSerializer
+    def type, do: "likes"
+    location "/likes/:id"
+  end
+
+  defmodule ExcerptSerializer do
+    use JaSerializer
+    def type, do: "excerpts"
+    location "/excerpts/:id"
     attributes [:body]
   end
 
@@ -123,7 +156,8 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
       id: 1,
       title: "JSON API paints my bikeshed!",
       author: author,
-      comments: [c1, c2]
+      comments: [c1, c2],
+      likes: [],
     }
 
     model = %Scrivener.Page{

--- a/test/ja_serializer/json_api_spec/resource_object_test.exs
+++ b/test/ja_serializer/json_api_spec/resource_object_test.exs
@@ -18,6 +18,17 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
             "related": "/articles/1/author"
           },
           "data": { "type": "people", "id": "9" }
+        },
+        "comments": {
+          "links": {
+            "related": "/articles/1/comments"
+          }
+        },
+        "likes": {
+          "data": []
+        },
+        "excerpt": {
+          "data": null
         }
       }
     }
@@ -32,6 +43,12 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
     has_one :author,
       link: "/articles/:id/author",
       type: "people"
+    has_many :comments,
+      link: "/articles/:id/comments"
+    has_many :likes,
+      type: "like"
+    has_one :excerpt,
+      type: "excerpt"
   end
 
   test "it serializes properly" do
@@ -46,7 +63,8 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
       id: 1,
       title: "Rails is Omakase",
       author: author,
-      comments: []
+      comments: [],
+      likes: []
     }
 
     results = article

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,9 +6,17 @@ defmodule TestModel.Person do
 end
 
 defmodule TestModel.Article do
-  defstruct [:id, :title, :author, :comments, :body]
+  defstruct [:id, :title, :author, :comments, :body, :likes, :excerpt]
 end
 
 defmodule TestModel.Comment do
   defstruct [:id, :body, :author]
+end
+
+defmodule TestModel.Like do
+  defstruct [:id]
+end
+
+defmodule TestModel.Excerpt do
+  defstruct [:id, :body]
 end


### PR DESCRIPTION
Here's my first attempt at fixing #26, though it's definitely not ready to merge yet.

I agree on the integration test, so I started with that. I added `has_many :likes` and `has_one :excerpt` and set them both to be empty. As expected, the test fails.

To handle a blank `has_one`, I updated the `ResourceIdentifier` formatter to format an empty relationship as `nil` (instead of a resource identifier object with a blank `id` field, e.g. ```{"type": "excerpt", "id"; ""}```).

Next, I updated `put_if_present` in the `Utils` module to explicitly add `nil`/ `[]` to `dict` only when it's for the `:data` key. However:

1. While the JSON API spec only requires explicit `null`/`[]` values when dealing with the `data` object, I don't really like explicitly matching on the `:data` key. But maybe I'm just overthinking it.
2. More importantly, because of this approach (specifically, the guard clause on the `nil` case), `{"data": ...}` will be added to **every** relationship in the output, even if we didn't ask it to (e.g. we may have just asked for `has_one :excerpt, link: "..."`). And even worse, if we didn't ask for `:data`, it'll be set to `null` even if there really are items in the relationship.

So now I'm stuck. The `JaSerializer.Builder.Relationship` struct includes the `:data` key, which defaults to `nil`. If we have an empty has_one relationship, that also sets `:data` to nil. So how do we tell the difference between "it's nil because we never set it to anything" vs "it's nil because that's specifically what we want"? (This is why I originally suggested using a `:null_value` atom, though I agree that doesn't feel right).