### PR TITLE
Adding support for relationships with custom ids.

### DIFF
--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -29,6 +29,7 @@ defmodule JaSerializer.Builder.Relationship do
     |> case do
       nil  -> relation
       type ->
+        context = Map.put(context, :resource_serializer, opts[:include])
         Map.put(relation, :data, ResourceIdentifier.build(context, type, name))
     end
   end

--- a/lib/ja_serializer/builder/resource_identifier.ex
+++ b/lib/ja_serializer/builder/resource_identifier.ex
@@ -9,16 +9,26 @@ defmodule JaSerializer.Builder.ResourceIdentifier do
     |> case do
       [] -> [:empty_relationship]
       nil -> :empty_relationship
-      many when is_list(many) -> Enum.map(many, &build(&1, type))
-      one -> build(one, type)
+      many when is_list(many) -> Enum.map(many, &build(&1, type, context))
+      one -> build(one, type, context)
     end
   end
 
+  def build(%{} = model, type, %{resource_serializer: resource_serializer} = context) do
+    id = cond do
+      resource_serializer ->
+        apply(resource_serializer, :id, [model, context.conn])
+      true ->
+        Map.get(model, :id)
+    end
+
+    build(id, type)
+  end
+
   def build(%{} = model, type) do
-    %__MODULE__{
-      type: type,
-      id: Map.get(model, :id)
-    }
+    id = Map.get(model, :id)
+
+    build(id, type)
   end
 
   def build(id, type) do

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -1,0 +1,48 @@
+defmodule JaSerializer.Builder.RelationshipTest do
+  use ExUnit.Case
+
+  defmodule ArticleSerializer do
+    use JaSerializer
+
+    def type, do: "articles"
+    attributes [:title]
+    has_many :comments,
+      include: JaSerializer.Builder.RelationshipTest.CommentSerializer
+  end
+
+  defmodule CommentSerializer do
+    use JaSerializer
+    def id(model, _conn), do: model.comment_id
+    def type, do: "comments"
+    location "/comments/:id"
+    attributes [:body]
+  end
+
+  test "custom id def respected in relationship data" do
+    c1 = %TestModel.CustomIdComment{comment_id: "c1", body: "c1"}
+    c2 = %TestModel.CustomIdComment{comment_id: "c2", body: "c2"}
+    a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1, c2]}
+
+    context = %{model: a1, conn: %{}, serializer: ArticleSerializer, opts: []}
+    primary_resource = JaSerializer.Builder.ResourceObject.build(context)
+
+    %JaSerializer.Builder.ResourceObject{
+      relationships: [%JaSerializer.Builder.Relationship{:data => rel_data}]
+    } = primary_resource
+
+    assert [_,_] = rel_data
+
+    ids = Enum.map(rel_data, &(&1.id))
+    assert "c1" in ids
+    assert "c2" in ids
+
+    # Formatted
+    json = ArticleSerializer.format(a1)
+    assert %{relationships: %{"comments" => comments}} = json[:data]
+    assert [_,_] = comments[:data]
+
+    formatted_ids = Enum.map(comments[:data], &(&1.id))
+    assert "c1" in formatted_ids
+    assert "c2" in formatted_ids
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,6 +13,10 @@ defmodule TestModel.Comment do
   defstruct [:id, :body, :author]
 end
 
+defmodule TestModel.CustomIdComment do
+  defstruct [:comment_id, :body, :author]
+end
+
 defmodule TestModel.Like do
   defstruct [:id]
 end


### PR DESCRIPTION
When a related resource has a custom id def in its serializer, that custom id should be used when specifying resource identifiers that go under the relationships data property.

**Edit:** Changed resource *objects* to resource *identifiers*