### PR TITLE
Specify serializer for relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ defmodule MyApp.ArticleSerializer do
   attributes [:title, :tags, :body, :excerpt]
 
   has_one :author,
-    include: PersonSerializer,
+    serializer: PersonSerializer,
+    include: true,
     field: :authored_by
 
   has_many :comments,

--- a/lib/ja_serializer/builder/included.ex
+++ b/lib/ja_serializer/builder/included.ex
@@ -35,6 +35,9 @@ defmodule JaSerializer.Builder.Included do
   # Find relationships that should be included.
   defp relationships_with_include(context) do
     context.serializer.__relations
+    # This filter is where we would test for opts[:include]
+    # OR
+    # opts[:optional_include] AND user specified this relationship should be included
     |> Enum.filter(fn({_t, _n, opts}) -> opts[:include] == true end)
   end
 

--- a/lib/ja_serializer/builder/included.ex
+++ b/lib/ja_serializer/builder/included.ex
@@ -35,17 +35,17 @@ defmodule JaSerializer.Builder.Included do
   # Find relationships that should be included.
   defp relationships_with_include(context) do
     context.serializer.__relations
-    |> Enum.filter(fn({_t, _n, opts}) -> opts[:include] != nil end)
+    |> Enum.filter(fn({_t, _n, opts}) -> opts[:include] == true end)
   end
 
   # Find resources for relationship & parent_context
   defp resources_for_relationship({_, name, opts}, context, included, known) do
     new = apply(context.serializer, name, [context.model, context.conn])
           |> List.wrap
-          |> resource_objects_for(context.conn, opts[:include])
+          |> resource_objects_for(context.conn, opts[:serializer])
           |> reject_known(included, known)
 
-    child_context = Map.put(context, :serializer, opts[:include])
+    child_context = Map.put(context, :serializer, opts[:serializer])
 
     new
     |> Enum.map(&(&1.model))

--- a/lib/ja_serializer/builder/included.ex
+++ b/lib/ja_serializer/builder/included.ex
@@ -38,17 +38,21 @@ defmodule JaSerializer.Builder.Included do
     # This filter is where we would test for opts[:include]
     # OR
     # opts[:optional_include] AND user specified this relationship should be included
-    |> Enum.filter(fn({_t, _n, opts}) -> opts[:include] == true end)
+    |> Enum.filter(fn({_t, _n, opts}) ->
+      %{:serializer => serializer, :include => include} = normalize_relation_opts(opts, true)
+      include == true
+    end)
   end
 
   # Find resources for relationship & parent_context
   defp resources_for_relationship({_, name, opts}, context, included, known) do
+    %{:serializer => serializer} = normalize_relation_opts(opts)
     new = apply(context.serializer, name, [context.model, context.conn])
           |> List.wrap
-          |> resource_objects_for(context.conn, opts[:serializer])
+          |> resource_objects_for(context.conn, serializer)
           |> reject_known(included, known)
 
-    child_context = Map.put(context, :serializer, opts[:serializer])
+    child_context = Map.put(context, :serializer, serializer)
 
     new
     |> Enum.map(&(&1.model))
@@ -57,5 +61,24 @@ defmodule JaSerializer.Builder.Included do
 
   defp reject_known(resources, included, primary) do
     Enum.reject(resources, &(&1 in included || &1 in primary))
+  end
+
+  defp normalize_relation_opts(opts, trigger_deprecation \\ false) do
+    include = opts[:include]
+
+    case is_boolean(include) or is_nil(include) do
+      true -> %{serializer: opts[:serializer], include: opts[:include]}
+      false ->
+        if trigger_deprecation do
+          IO.write :stderr, "[warning] specifying a non-boolean as the `include` " <>
+            "option is deprecated.\n" <>
+            "[warning] If you are specifying the serializer for this relation, " <> "
+            use the new `serializer` option instead.\n" <>
+            "[warning] To always side-load the relationship, provide the `include` " <>
+            "option with a value of `true` in addition to `serializer.\n"
+        end
+
+        %{serializer: include, include: true}
+    end
   end
 end

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -29,13 +29,13 @@ defmodule JaSerializer.Builder.Relationship do
     |> case do
       nil  -> relation
       type ->
-        context = Map.put(context, :resource_serializer, opts[:include])
+        context = Map.put(context, :resource_serializer, opts[:serializer])
         Map.put(relation, :data, ResourceIdentifier.build(context, type, name))
     end
   end
 
   defp type_from_opts(opts) do
-    case {opts[:type], opts[:include]} do
+    case {opts[:type], opts[:serializer]} do
       {nil, nil}        -> nil
       {nil, serializer} -> apply(serializer, :type, [])
       {type, _}         -> type

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -2,8 +2,8 @@ defmodule JaSerializer.Serializer do
   @moduledoc """
   Define a serialization schema.
 
-  Provides `has_many/2`, `has_one/2`, `attributes\1` and `location\1` macros 
-  to define how your model (struct or map) will be rendered in the 
+  Provides `has_many/2`, `has_one/2`, `attributes\1` and `location\1` macros
+  to define how your model (struct or map) will be rendered in the
   JSONAPI.org 1.0 format.
 
   Defines `format/1`, `format/2` and `format/3` used to convert models (and
@@ -17,7 +17,7 @@ defmodule JaSerializer.Serializer do
         location "/posts/:id"
         attributes [:title, :body, :excerpt, :tags]
         has_many :comments, link: "/posts/:id/comments"
-        has_one :author, include: PersonSerializer
+        has_one :author, serializer: PersonSerializer, include: true
 
         def excerpt(post, _conn) do
           [first | _ ] = String.split(post.body, ".")
@@ -321,7 +321,7 @@ defmodule JaSerializer.Serializer do
       defmodule PostSerializer do
         use JaSerializer
 
-        has_many :comments, include: CommentSerializer
+        has_many :comments, serializer: CommentSerializer, include: true
 
         def comments(post, _conn) do
           post |> PostModel.get_comments

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -14,6 +14,15 @@ defmodule JaSerializer.Builder.IncludedTest do
       include: true
   end
 
+  defmodule DeprecatedArticalSerializer do
+    use JaSerializer
+
+    def type, do: "articles"
+    attributes [:title]
+    has_many :comments,
+      include: JaSerializer.Builder.IncludedTest.CommentSerializer
+  end
+
   defmodule PersonSerializer do
     use JaSerializer
     def type, do: "people"
@@ -78,5 +87,23 @@ defmodule JaSerializer.Builder.IncludedTest do
     json = ArticleSerializer.format(a1)
     assert %{} = json[:data]
     assert [_,_,_] = json[:included]
+  end
+
+  test "specifying a serializer as the `include` option still works" do
+    c1 = %TestModel.Comment{id: "c1", body: "c1"}
+    a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1]}
+
+    context = %{model: a1, conn: %{}, serializer: DeprecatedArticalSerializer, opts: []}
+    primary_resource = JaSerializer.Builder.ResourceObject.build(context)
+    includes = JaSerializer.Builder.Included.build(context, primary_resource)
+
+    ids = Enum.map(includes, &(&1.id))
+    assert [_] = includes
+    assert "c1" in ids
+
+    # Formatted
+    json = ArticleSerializer.format(a1)
+    assert %{} = json[:data]
+    assert [_] = json[:included]
   end
 end

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -7,9 +7,11 @@ defmodule JaSerializer.Builder.IncludedTest do
     def type, do: "articles"
     attributes [:title]
     has_many :comments,
-      include: JaSerializer.Builder.IncludedTest.CommentSerializer
+      serializer: JaSerializer.Builder.IncludedTest.CommentSerializer,
+      include: true
     has_one :author,
-      include: JaSerializer.Builder.IncludedTest.PersonSerializer
+      serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
+      include: true
   end
 
   defmodule PersonSerializer do
@@ -24,9 +26,11 @@ defmodule JaSerializer.Builder.IncludedTest do
     location "/comments/:id"
     attributes [:body]
     has_one :author,
-      include: JaSerializer.Builder.IncludedTest.PersonSerializer
+      serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
+      include: true
     has_many :comments,
-      include: JaSerializer.Builder.IncludedTest.CommentSerializer
+      serializer: JaSerializer.Builder.IncludedTest.CommentSerializer,
+      include: true
   end
 
   test "multiple levels of includes are respected" do

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -14,7 +14,7 @@ defmodule JaSerializer.Builder.IncludedTest do
       include: true
   end
 
-  defmodule DeprecatedArticalSerializer do
+  defmodule DeprecatedArticleSerializer do
     use JaSerializer
 
     def type, do: "articles"
@@ -93,7 +93,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     c1 = %TestModel.Comment{id: "c1", body: "c1"}
     a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1]}
 
-    context = %{model: a1, conn: %{}, serializer: DeprecatedArticalSerializer, opts: []}
+    context = %{model: a1, conn: %{}, serializer: DeprecatedArticleSerializer, opts: []}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -7,7 +7,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
     def type, do: "articles"
     attributes [:title]
     has_many :comments,
-      include: JaSerializer.Builder.RelationshipTest.CommentSerializer
+      serializer: JaSerializer.Builder.RelationshipTest.CommentSerializer,
+      include: true
   end
 
   defmodule CommentSerializer do

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -95,16 +95,20 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     attributes [:title]
     has_many :comments,
       link: "/articles/:id/comments",
-      include: CommentSerializer
+      serializer: CommentSerializer,
+      include: true
     has_one :author,
       link: "/articles/:id/author",
-      include: PersonSerializer
+      serializer: PersonSerializer,
+      include: true
     has_many :likes,
       link: "/articles/:id/likes",
-      include: LikeSerializer
+      serializer: LikeSerializer,
+      include: true
     has_one :excerpt,
       link: "/articles/:id/excerpt",
-      include: ExcerptSerializer
+      serializer: ExcerptSerializer,
+      include: true
   end
 
   defmodule PersonSerializer do


### PR DESCRIPTION
Moving `:include` option to new `:serializer` option. `:include` option becomes a boolean.

See #31 for additional details.