### PR TITLE
Make Ecto a required dependency.

### DIFF
--- a/lib/ja_serializer/ecto_error_serializer.ex
+++ b/lib/ja_serializer/ecto_error_serializer.ex
@@ -1,39 +1,37 @@
-if Code.ensure_loaded?(Ecto) do
-  defmodule JaSerializer.EctoErrorSerializer do
-    alias JaSerializer.Formatter.Utils
+defmodule JaSerializer.EctoErrorSerializer do
+  alias JaSerializer.Formatter.Utils
 
-    def format(errors), do: format(errors, %{})
-    def format(errors, conn), do: format(errors, conn, [])
-    def format(%Ecto.Changeset{} = cs, c, o), do: format(cs.errors, c, o)
-    def format(errors, _conn, _) do
-      errors
-      |> Enum.map(&format_each/1)
-      |> JaSerializer.ErrorSerializer.format
-    end
+  def format(errors), do: format(errors, %{})
+  def format(errors, conn), do: format(errors, conn, [])
+  def format(%Ecto.Changeset{} = cs, c, o), do: format(cs.errors, c, o)
+  def format(errors, _conn, _) do
+    errors
+    |> Enum.map(&format_each/1)
+    |> JaSerializer.ErrorSerializer.format
+  end
 
-    defp format_each({field, {message, vals}}) do
-      message = Regex.replace(~r/%{count}/, message, "#{vals[:count]}")
-      %{
-        source: %{ pointer: pointer_for(field) },
-        detail: message
-      }
-    end
+  defp format_each({field, {message, vals}}) do
+    message = Regex.replace(~r/%{count}/, message, "#{vals[:count]}")
+    %{
+      source: %{ pointer: pointer_for(field) },
+      detail: message
+    }
+  end
 
-    defp format_each({field, message}) do
-      %{
-        source: %{ pointer: pointer_for(field) },
-        detail: message
-      }
-    end
+  defp format_each({field, message}) do
+    %{
+      source: %{ pointer: pointer_for(field) },
+      detail: message
+    }
+  end
 
-    # Assumes relationship name is the same as the field name without the id.
-    # This is a fairly large and incorrect assumption, but until we have better
-    # ideas this will work for most relationships.
-    defp pointer_for(field) do
-      case Regex.run(~r/(.*)_id$/, to_string(field)) do
-        nil      -> "/data/attributes/#{Utils.format_key(field)}"
-        [_, rel] -> "/data/relationships/#{Utils.fomat_key(rel)}"
-      end
+  # Assumes relationship name is the same as the field name without the id.
+  # This is a fairly large and incorrect assumption, but until we have better
+  # ideas this will work for most relationships.
+  defp pointer_for(field) do
+    case Regex.run(~r/(.*)_id$/, to_string(field)) do
+      nil      -> "/data/attributes/#{Utils.format_key(field)}"
+      [_, rel] -> "/data/relationships/#{Utils.fomat_key(rel)}"
     end
   end
 end

--- a/lib/ja_serializer/formatter.ex
+++ b/lib/ja_serializer/formatter.ex
@@ -15,14 +15,10 @@ defimpl JaSerializer.Formatter, for: [BitString, Integer, Float, Atom] do
   def format(data), do: data
 end
 
-if Code.ensure_loaded?(Ecto) do
-  defimpl JaSerializer.Formatter, for: [Ecto.DateTime, Ecto.Time, Ecto.Date] do
-    def format(dt), do: dt
-  end
+defimpl JaSerializer.Formatter, for: [Ecto.DateTime, Ecto.Time, Ecto.Date] do
+  def format(dt), do: dt
 end
 
-if Code.ensure_loaded?(Decimal) do
-  defimpl JaSerializer.Formatter, for: [Decimal] do
-    def format(dt), do: dt
-  end
+defimpl JaSerializer.Formatter, for: [Decimal] do
+  def format(dt), do: dt
 end

--- a/lib/ja_serializer/phoenix_view.ex
+++ b/lib/ja_serializer/phoenix_view.ex
@@ -91,10 +91,8 @@ defmodule JaSerializer.PhoenixView do
     |> apply(:format, [errors, data[:conn], data[:opts]])
   end
 
-  if Code.ensure_loaded?(Ecto) do
-    defp error_serializer(%Ecto.Changeset{}) do
-      JaSerializer.EctoErrorSerializer
-    end
+  defp error_serializer(%Ecto.Changeset{}) do
+    JaSerializer.EctoErrorSerializer
   end
 
   defp error_serializer(_) do

--- a/lib/ja_serializer/relationship.ex
+++ b/lib/ja_serializer/relationship.ex
@@ -1,28 +1,26 @@
-if Code.ensure_loaded?(Ecto) do
-  defmodule JaSerializer.AssociationNotLoadedError do
-    defexception [:message]
+defmodule JaSerializer.AssociationNotLoadedError do
+  defexception [:message]
 
-    def exception(opts) do
-      msg = """
-      The #{opts[:rel]} relationship returned %Ecto.Association.NotLoaded{}.
+  def exception(opts) do
+    msg = """
+    The #{opts[:rel]} relationship returned %Ecto.Association.NotLoaded{}.
 
-      Please pre-fetch the relationship before serialization or override the
-      #{opts[:name]}/2 function in your serializer.
+    Please pre-fetch the relationship before serialization or override the
+    #{opts[:name]}/2 function in your serializer.
 
-      Example:
+    Example:
 
-          def #{opts[:name]}(model, conn) do
-            case model.#{opts[:rel]} do
-              %Ecto.Association.NotLoaded{} ->
-                model
-                |> Ecto.Model.assoc(:#{opts[:rel]})
-                |> MyApp.Repo.all
-              other -> other
-            end
+        def #{opts[:name]}(model, conn) do
+          case model.#{opts[:rel]} do
+            %Ecto.Association.NotLoaded{} ->
+              model
+              |> Ecto.Model.assoc(:#{opts[:rel]})
+              |> MyApp.Repo.all
+            other -> other
           end
-      """
-      %JaSerializer.AssociationNotLoadedError{message: msg}
-    end
+        end
+    """
+    %JaSerializer.AssociationNotLoadedError{message: msg}
   end
 end
 
@@ -39,24 +37,15 @@ defmodule JaSerializer.Relationship do
     end
   end
 
-  if Code.ensure_loaded?(Ecto) do
-    @error JaSerializer.AssociationNotLoadedError
-    # If ecto is loaded we try to load relationships appropriately
-    def get_data(model, name, opts) do
-      rel = (opts[:field] || name)
-      model
-      |> Map.get(rel)
-      |> case do
-        %Ecto.Association.NotLoaded{} -> raise @error, rel: rel, name: name
-        other -> other
-      end
-    end
-
-  else
-
-    # If ecto is not loaded we just return the struct field.
-    def get_data(model, name, opts) do
-      Map.get(model, (opts[:field] || name))
+  @error JaSerializer.AssociationNotLoadedError
+  # If ecto is loaded we try to load relationships appropriately
+  def get_data(model, name, opts) do
+    rel = (opts[:field] || name)
+    model
+    |> Map.get(rel)
+    |> case do
+      %Ecto.Association.NotLoaded{} -> raise @error, rel: rel, name: name
+      other -> other
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule JaSerializer.Mixfile do
   defp deps do
     [{:inflex, "~> 1.4"},
      {:plug, "~> 1.0"},
-     {:ecto, "~> 1.0", optional: true},
+     {:ecto, "~> 1.0"},
      {:poison, "~> 1.4"},
      {:earmark, "~> 0.1", only: :dev},
      {:inch_ex, "~> 0.4", only: :docs},


### PR DESCRIPTION
ja_serializer is a primarially a serializer for Ecto apps. Let's embrace
that. This fixes #34.