### PR TITLE
fomat_key typo in ecto_error_serializer

### DIFF
--- a/lib/ja_serializer/ecto_error_serializer.ex
+++ b/lib/ja_serializer/ecto_error_serializer.ex
@@ -31,7 +31,7 @@ defmodule JaSerializer.EctoErrorSerializer do
   defp pointer_for(field) do
     case Regex.run(~r/(.*)_id$/, to_string(field)) do
       nil      -> "/data/attributes/#{Utils.format_key(field)}"
-      [_, rel] -> "/data/relationships/#{Utils.fomat_key(rel)}"
+      [_, rel] -> "/data/relationships/#{Utils.format_key(rel)}"
     end
   end
 end


### PR DESCRIPTION
Fixed a little typo in ecto_error_serializer