### PR TITLE
Refactor link builder to support more options on the link params parsing

### DIFF
--- a/lib/ja_serializer/builder/link.ex
+++ b/lib/ja_serializer/builder/link.ex
@@ -1,6 +1,8 @@
 defmodule JaSerializer.Builder.Link do
   @moduledoc false
 
+  @param_fetcher_regex ~r/:\w+/
+
   defstruct href: nil, meta: nil, type: :related
 
   def build(_context, _type, nil), do: nil
@@ -20,15 +22,11 @@ defmodule JaSerializer.Builder.Link do
   end
 
   defp path_for_context(context, path) do
-    path
-    |> String.split("/")
-    |> Enum.map(&frag_for_context(&1, context))
-    |> Enum.join("/")
+    @param_fetcher_regex
+    |> Regex.replace(path, &frag_for_context(&1, context))
   end
 
   defp frag_for_context(":" <> frag, %{serializer: serializer} = context) do
     "#{apply(serializer, String.to_atom(frag), [context.model, context.conn])}"
   end
-
-  defp frag_for_context(frag, _context), do: frag
 end

--- a/test/ja_serializer/builder/link_test.exs
+++ b/test/ja_serializer/builder/link_test.exs
@@ -1,0 +1,53 @@
+defmodule JaSerializer.Builder.LinkTest do
+  use ExUnit.Case
+
+  defmodule ArticleSerializer do
+    use JaSerializer
+
+    has_many :comments,
+      serializer: JaSerializer.Builder.LinkTest.CommentSerializer,
+      link: "comments?article_id=:id"
+  end
+
+  defmodule PostSerializer do
+    use JaSerializer
+
+    has_many :comments,
+      serializer: JaSerializer.Builder.LinkTest.CommentSerializer,
+      link: "articles/:id/comments"
+  end
+
+  defmodule CommentSerializer do
+    use JaSerializer
+  end
+
+  test "id in url path" do
+    c1 = %TestModel.Comment{id: "c1", body: "c1"}
+    c2 = %TestModel.Comment{id: "c2", body: "c2"}
+    a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1, c2]}
+
+    context = %{model: a1, conn: %{}, serializer: ArticleSerializer, opts: []}
+    primary_resource = JaSerializer.Builder.ResourceObject.build(context)
+
+    %JaSerializer.Builder.ResourceObject{
+      relationships: [%JaSerializer.Builder.Relationship{:links => [%JaSerializer.Builder.Link{href: href}]}]
+    } = primary_resource
+
+    assert href == "comments?article_id=a1"
+  end
+
+  test "id in query params" do
+    c1 = %TestModel.Comment{id: "c1", body: "c1"}
+    c2 = %TestModel.Comment{id: "c2", body: "c2"}
+    a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1, c2]}
+
+    context = %{model: a1, conn: %{}, serializer: PostSerializer, opts: []}
+    primary_resource = JaSerializer.Builder.ResourceObject.build(context)
+
+    %JaSerializer.Builder.ResourceObject{
+      relationships: [%JaSerializer.Builder.Relationship{:links => [%JaSerializer.Builder.Link{href: href}]}]
+    } = primary_resource
+
+    assert href == "articles/a1/comments"
+  end
+end


### PR DESCRIPTION
I needed to support link like `"comments?article_id=:id"`. So I refactored the `path_for_context` function in the `Builder.Link` module.

The function now replace every occurence of `:` +_n_ word character (so it stops matching on `&` or `/`) and replace it with the `frag_for_context` return. As the regex always match with `:` the empty `frag_for_context` function is not needed anymore!