### PR TITLE
Skip content-type verification on DELETE requests

### DIFF
--- a/lib/ja_serializer/content_type_negotiation.ex
+++ b/lib/ja_serializer/content_type_negotiation.ex
@@ -31,6 +31,7 @@ if Code.ensure_loaded?(Plug) do
 
     def verify_content_type(%Plug.Conn{method: "HEAD"} = conn, _o), do: conn
     def verify_content_type(%Plug.Conn{method: "GET"} = conn, _o), do: conn
+    def verify_content_type(%Plug.Conn{method: "DELETE"} = conn, _o), do: conn
     def verify_content_type(%Plug.Conn{} = conn, _o) do
       if Enum.member?(get_req_header(conn, "content-type"), @jsonapi) do
         conn

--- a/test/ja_serializer/content_type_negotiation_test.exs
+++ b/test/ja_serializer/content_type_negotiation_test.exs
@@ -24,6 +24,14 @@ defmodule JaSerializer.ContentTypeNegotiationTest do
     assert result.resp_body == "success"
   end
 
+  test "Passes no content-type and valid accept header through on DELETE" do
+    conn = Plug.Test.conn("DELETE", "/", %{})
+            |> put_req_header("accept", @valid)
+    result = ExamplePlug.call(conn, [])
+    assert result.status == 200
+    assert result.resp_body == "success"
+  end
+
   test "Returns 415 Unsupported Media Type if any media type params" do
     conn = Plug.Test.conn("POST", "/", %{})
             |> put_req_header("content-type", @invalid)


### PR DESCRIPTION
Some frontend frameworks, such as [Ember](http://emberjs.com), skips the content-type header when there is no data to be sent. The current ContentTypeNegotiation plug halts all such requests.

As far as I can tell this change complies with the [specification](http://jsonapi.org/format/#crud-deleting).