### PR TITLE
Add all required dependencies to applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule JaSerializer.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :inflex, :plug, :ecto, :poison]]
   end
 
   defp deps do


### PR DESCRIPTION
I'm using [exrm](https://github.com/bitwalker/exrm) to deploy my Phoenix app, and per their [common issues page](https://github.com/bitwalker/exrm/blob/master/docs/Common%20Issues.md), all dependencies must be listed in the `:applications` block. In addition, if a dependency's `mix.exs` file doesn't list _its_ dependencies, you need to list those as well. Otherwise, those dependencies' modules won't be available.

This is the case with `Inflex`. When using ja_serializer in production, I was having errors as soon as it tried to use the Inflex module. I fixed it by manually adding `:inflex` to the `:applications` list in my own app, but based on that common issues page, and looking at the `:applications` list of several other popular packages (postgrex, ecto, httpoison, etc.), ja_serializer should probably list its required dependencies under `:applications`.