### PR TITLE
Add Humanized field name to Ecto Error Serializer 

### DIFF
--- a/lib/ja_serializer/ecto_error_serializer.ex
+++ b/lib/ja_serializer/ecto_error_serializer.ex
@@ -21,7 +21,8 @@ defmodule JaSerializer.EctoErrorSerializer do
   defp format_each({field, message}) do
     %{
       source: %{ pointer: pointer_for(field) },
-      detail: message
+      title: message,
+      detail: "#{Utils.humanize(field)} #{message}"
     }
   end
 

--- a/lib/ja_serializer/formatter/utils.ex
+++ b/lib/ja_serializer/formatter/utils.ex
@@ -34,4 +34,18 @@ defmodule JaSerializer.Formatter.Utils do
   def do_format_key(key, :underscored), do: key
   def do_format_key(key, :dasherized), do: String.replace(key, @dasherize, "-")
   def do_format_key(key, {:custom, module, fun}), do: apply(module, fun, [key])
+
+  @doc false
+  def humanize(atom) when is_atom(atom),
+    do: humanize(Atom.to_string(atom))
+  def humanize(bin) when is_binary(bin) do
+    bin =
+      if String.ends_with?(bin, "_id") do
+        binary_part(bin, 0, byte_size(bin) - 3)
+      else
+        bin
+      end
+
+    bin |> String.replace("_", " ") |> String.capitalize
+  end
 end

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -1,0 +1,33 @@
+defmodule JaSerializer.EctoErrorSerializerTest do
+  use ExUnit.Case
+
+  alias JaSerializer.EctoErrorSerializer
+
+  test "Will correctly format a changeset with an error" do
+    expected = %{
+      errors: [
+        %{source: %{pointer: "/data/attributes/title"}, title: "is invalid", detail: "Title is invalid"}
+      ]
+    }
+
+    assert expected == EctoErrorSerializer.format(
+      Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid")
+    )
+  end
+
+  test "Will correctly format a changeset with multiple errors on one attribute" do
+    expected = %{
+      errors: [
+        %{source: %{pointer: "/data/attributes/title"}, title: "shouldn't be blank", detail: "Title shouldn't be blank"},
+        %{source: %{pointer: "/data/attributes/title"}, title: "is invalid", detail: "Title is invalid"}
+      ]
+    }
+
+    changeset = %Ecto.Changeset{}
+    |> Ecto.Changeset.add_error(:title, "is invalid")
+    |> Ecto.Changeset.add_error(:title, "shouldn't be blank")
+
+    assert expected == EctoErrorSerializer.format(changeset)
+  end
+
+end

--- a/test/ja_serializer/formatter/utils_test.exs
+++ b/test/ja_serializer/formatter/utils_test.exs
@@ -16,6 +16,19 @@ defmodule JaSerializer.Formatter.UtilsTest do
     assert Utils.do_format_key("approved_comments", :underscored) == "approved_comments"
   end
 
+  test "Will humanize a string" do
+    assert Utils.humanize("title") == "Title"
+    assert Utils.humanize("first_name") == "First name"
+  end
+
+  test "Will omit the _id portion of a string when humanizing" do
+    assert Utils.humanize("user_id") == "User"
+  end
+
+  test "Will humanize an atom" do
+    assert Utils.humanize(:title) == "Title"
+  end
+
   def smasherize(key), do: String.replace(key, ~r/_/, "")
 
   test "formatting keys - custom" do

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -34,7 +34,7 @@ defmodule JaSerializer.PhoenixViewTest do
   end
 
   test "render conn, index.json, model: model with custom pagination", c do
-    json = @view.render("index.json", conn: %{}, model: [c[:m1], c[:m2]], 
+    json = @view.render("index.json", conn: %{}, model: [c[:m1], c[:m2]],
       opts: [page: [first: "/v1/posts/foo"]])
     assert [a1, _a2] = json[:data]
     assert Dict.has_key?(a1, :id)
@@ -65,11 +65,11 @@ defmodule JaSerializer.PhoenixViewTest do
   end
 
   test "render conn, 'errors.json', data: changeset" do
-    errors = Ecto.Changeset.add_error(%Ecto.Changeset{}, :invalid, "is invalid")
+    errors = Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid")
     json = @view.render("errors.json", conn: %{}, data: errors)
     assert Dict.has_key?(json, :errors)
     assert [e1] = json[:errors]
-    assert e1.source.pointer == "/data/attributes/invalid"
-    assert e1.detail == "is invalid"
+    assert e1.source.pointer == "/data/attributes/title"
+    assert e1.detail == "Title is invalid"
   end
 end


### PR DESCRIPTION
This PR adds a humanized field name prepended to the error message for the `detail` field as noted in issue #50. I added the `humanize/1` method from Phoenix to the Utils in order to do this.

In addition, this PR also adds the `title` attribute to the `EctoErrorSerializer` to better conform to the JSON API spec.