### PR TITLE
Retain `type` key during deserialization

### DIFF
--- a/lib/ja_serializer/deserializer.ex
+++ b/lib/ja_serializer/deserializer.ex
@@ -40,6 +40,7 @@ if Code.ensure_loaded?(Plug) do
     defp format_keys(%{"data" => data} = params) do
       Map.merge(params, %{
         "data" => %{
+          "type" => data["type"],
           "attributes" => do_format_keys(data["attributes"]),
           "relationships" => do_format_keys(data["relationships"])
         }

--- a/test/ja_serializer/deserializer_test.exs
+++ b/test/ja_serializer/deserializer_test.exs
@@ -48,4 +48,17 @@ defmodule JaSerializer.DeserializerTest do
     assert result.params["data"]["attributes"]["some_nonsense"]
     assert result.params["data"]["attributes"]["foo_bar"]
   end
+
+  test "retains payload type" do
+    req_body = Poison.encode!(%{
+      "data" => %{
+        "type" => "foo"
+      }
+    })
+    conn = Plug.Test.conn("POST", "/", req_body)
+            |> put_req_header("content-type", @ct)
+            |> put_req_header("accept", @ct)
+    result = ExamplePlug.call(conn, [])
+    assert result.params["data"]["type"] == "foo"
+  end
 end


### PR DESCRIPTION
Currently, the `type` key for a JSONAPI payload is not retained during deserialization.