### PR TITLE
Format serializer `type` based on config format

### DIFF
--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -163,7 +163,7 @@ defmodule JaSerializer.Serializer do
             |> List.last
             |> String.replace("Serializer", "")
             |> String.replace("View", "")
-            |> String.downcase
+            |> JaSerializer.Formatter.Utils.format_type
     quote do
       def type, do: unquote(type)
       defoverridable [type: 0]

--- a/test/ja_serializer/formatter/utils_test.exs
+++ b/test/ja_serializer/formatter/utils_test.exs
@@ -35,4 +35,23 @@ defmodule JaSerializer.Formatter.UtilsTest do
     custom = {:custom, JaSerializer.Formatter.UtilsTest, :smasherize}
     assert Utils.do_format_key("approved_comments", custom) == "approvedcomments"
   end
+
+  test "formatting type - dasherize - by default" do
+    assert Utils.format_type("BlogPost") == "blog-post"
+    assert Utils.format_type("ApprovedComments") == "approved-comments"
+  end
+
+  test "formatting type - dasherize" do
+    assert Utils.format_type("BlogPost") == "blog-post"
+    assert Utils.do_format_type("ApprovedComments", :dasherized) == "approved-comments"
+  end
+
+  test "formatting type - underscored" do
+    assert Utils.do_format_type("ApprovedComments", :underscored) == "approved_comments"
+  end
+
+  test "formatting type - custom" do
+    custom = {:custom, JaSerializer.Formatter.UtilsTest, :smasherize}
+    assert Utils.do_format_type("approved_comments", custom) == "approvedcomments"
+  end
 end


### PR DESCRIPTION
Closes #27

This PR formats at resource's type based on the format options specified
in `config.exs`.

Defaults to dasherized type.

Specifying:

```exs
config :ja_serializer,
  key_format: :underscored
```

would result in MyApp.BookStoreView returning a type of `book_store`