### PR TITLE
Format query params

### DIFF
--- a/lib/ja_serializer/builder/scrivener_links.ex
+++ b/lib/ja_serializer/builder/scrivener_links.ex
@@ -46,7 +46,7 @@ if Code.ensure_loaded?(Scrivener) do
 
     defp page_url({key, val}, %{opts: opts, conn: conn, model: page}) do
       base = opts[:page][:base_url] || conn.request_path
-      page_params = %{"page" => %{"page" => val, "page_size" => page.page_size}}
+      page_params = JaSerializer.Formatter.Utils.deep_format_keys(%{"page" => %{"page" => val, "page_size" => page.page_size}})
       params = conn.query_params
                 |> Dict.merge(page_params)
                 |> Plug.Conn.Query.encode

--- a/lib/ja_serializer/formatter/utils.ex
+++ b/lib/ja_serializer/formatter/utils.ex
@@ -25,6 +25,19 @@ defmodule JaSerializer.Formatter.Utils do
   @key_formatter Application.get_env(:ja_serializer, :key_format, :dasherized)
 
   @doc false
+  def deep_format_keys(map) when is_map(map) do
+    Enum.reduce(map, %{}, &deep_format_key_value/2)
+  end
+  def deep_format_keys(other), do: other
+
+  defp deep_format_key_value({key, value}, accumulator) when is_map(value) do
+    Map.put(accumulator, format_key(key), deep_format_keys(value))
+  end
+  defp deep_format_key_value({key, value}, accumulator) do
+    Map.put(accumulator, format_key(key), value)
+  end
+
+  @doc false
   def format_key(k) when is_atom(k), do: k |> Atom.to_string |> format_key
   def format_key(key), do: do_format_key(key, @key_formatter)
 

--- a/test/ja_serializer/builder/scrivener_links_test.exs
+++ b/test/ja_serializer/builder/scrivener_links_test.exs
@@ -15,10 +15,10 @@ defmodule JaSerializer.Builder.ScrivenerLinksTest do
       opts: []
     }
     links = ScrivenerLinks.build(context)
-    assert URI.decode(links[:first]) == "?page[page]=1&page[page_size]=20"
-    assert URI.decode(links[:prev]) == "?page[page]=9&page[page_size]=20"
-    assert URI.decode(links[:next]) == "?page[page]=11&page[page_size]=20"
-    assert URI.decode(links[:last]) == "?page[page]=30&page[page_size]=20"
+    assert URI.decode(links[:first]) == "?page[page]=1&page[page-size]=20"
+    assert URI.decode(links[:prev]) == "?page[page]=9&page[page-size]=20"
+    assert URI.decode(links[:next]) == "?page[page]=11&page[page-size]=20"
+    assert URI.decode(links[:last]) == "?page[page]=30&page[page-size]=20"
   end
 
   test "when current page is first, do not include first, prev links" do
@@ -86,7 +86,7 @@ defmodule JaSerializer.Builder.ScrivenerLinksTest do
     }
     links = ScrivenerLinks.build(context)
 
-    assert links[:first] == "/api/v1/posts/?filter[foo]=bar&page[page]=1&page[page_size]=20"
+    assert links[:first] == "/api/v1/posts/?filter[foo]=bar&page[page]=1&page[page-size]=20"
   end
 
   test "url opts override conn url, old page params ignored" do
@@ -106,6 +106,6 @@ defmodule JaSerializer.Builder.ScrivenerLinksTest do
     }
     links = ScrivenerLinks.build(context)
 
-    assert links[:first] == "/api/v2/posts?page[page]=1&page[page_size]=20"
+    assert links[:first] == "/api/v2/posts?page[page]=1&page[page-size]=20"
   end
 end

--- a/test/ja_serializer/deserializer_test.exs
+++ b/test/ja_serializer/deserializer_test.exs
@@ -13,6 +13,13 @@ defmodule JaSerializer.DeserializerTest do
     end
   end
 
+  setup do
+    on_exit fn ->
+      Application.delete_env(:ja_serializer, :key_format)
+    end
+    :ok
+  end
+
   @ct "application/vnd.api+json"
 
   test "Ignores bodyless requests" do
@@ -23,13 +30,13 @@ defmodule JaSerializer.DeserializerTest do
     assert result.params == %{}
   end
 
-  test "Ignores non-jsonapi.org format params" do
+  test "converts non-jsonapi.org format params" do
     req_body = Poison.encode!(%{"some-nonsense" => "yup"})
     conn = Plug.Test.conn("POST", "/", req_body)
             |> put_req_header("content-type", @ct)
             |> put_req_header("accept", @ct)
     result = ExamplePlug.call(conn, [])
-    assert result.params == %{"some-nonsense" => "yup"}
+    assert result.params == %{"some_nonsense" => "yup"}
   end
 
   test "converts attribute key names" do
@@ -47,6 +54,26 @@ defmodule JaSerializer.DeserializerTest do
     result = ExamplePlug.call(conn, [])
     assert result.params["data"]["attributes"]["some_nonsense"]
     assert result.params["data"]["attributes"]["foo_bar"]
+  end
+
+  test "converts query param key names - dasherized" do
+    req_body = Poison.encode!(%{"data" => %{}})
+    conn = Plug.Test.conn("POST", "/?page[page-size]=2", req_body)
+            |> put_req_header("content-type", @ct)
+            |> put_req_header("accept", @ct)
+    result = ExamplePlug.call(conn, [])
+    assert result.params["page"]["page_size"] == "2"
+  end
+
+  test "converts query param key names - underscored" do
+    Application.put_env(:ja_serializer, :key_format, :underscored)
+
+    req_body = Poison.encode!(%{"data" => %{}})
+    conn = Plug.Test.conn("POST", "/?page[page_size]=2", req_body)
+            |> put_req_header("content-type", @ct)
+            |> put_req_header("accept", @ct)
+    result = ExamplePlug.call(conn, [])
+    assert result.query_params["page"]["page_size"] == "2"
   end
 
   test "retains payload type" do

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -44,11 +44,11 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
       }
     }],
     "links": {
-       "first": "/articles/?page[page]=1&page[page_size]=10",
-       "last": "/articles/?page[page]=5&page[page_size]=10",
-       "next": "/articles/?page[page]=4&page[page_size]=10",
-       "prev": "/articles/?page[page]=2&page[page_size]=10",
-       "self": "/articles/?page[page]=3&page[page_size]=10"
+       "first": "/articles/?page[page]=1&page[page-size]=10",
+       "last": "/articles/?page[page]=5&page[page-size]=10",
+       "next": "/articles/?page[page]=4&page[page-size]=10",
+       "prev": "/articles/?page[page]=2&page[page-size]=10",
+       "self": "/articles/?page[page]=3&page[page-size]=10"
      },
     "included": [{
       "type": "people",


### PR DESCRIPTION
Closes #64

This PR formats the query params in pagination links to be consistent with the configured `key_format`. It also will format dasherized params to underscores during deserialization.

Note: Because the pagination query params were always underscored and because the default key_format is dasherized, this may cause issues for people that are consuming pagination links that were relying on this behavior (Eg. they expect underscored query params even though key_format is configured to :dasherized).