### PR TITLE
Add ParamParser protocol to handle parsing params.

### DIFF
--- a/lib/ja_serializer/deserializer.ex
+++ b/lib/ja_serializer/deserializer.ex
@@ -35,51 +35,8 @@ if Code.ensure_loaded?(Plug) do
     @behaviour Plug
 
     def init(opts), do: opts
-    def call(conn, _opts), do: Map.put(conn, :params, format_params(conn.params))
-
-    defp format_params(%{"data" => %{"type" => _}} = params) do
-      {resource, other_params} = Map.pop(params, "data")
-      Map.merge(do_format_resource(resource), do_deep_format_keys(other_params))
+    def call(conn, _opts) do 
+      Map.put(conn, :params, JaSerializer.ParamParser.parse(conn.params))
     end
-    defp format_params(params) when is_map(params), do: do_deep_format_keys(params)
-
-    def do_format_resource(resource) do
-      Map.merge(resource, %{
-        "data" => %{
-          "type" => resource["type"],
-          "attributes" => do_format_keys(resource["attributes"]),
-          "relationships" => do_format_keys(resource["relationships"])
-        }
-      })
-    end
-
-    def do_deep_format_keys(map) when is_map(map) do
-      Enum.reduce(map, %{}, &do_format_key_value/2)
-    end
-
-    defp do_format_key_value({key, value}, accumulator) when is_map(value) do
-      Map.put(accumulator, format_key(key), do_deep_format_keys(value))
-    end
-    defp do_format_key_value({key, value}, accumulator) do
-      Map.put(accumulator, format_key(key), value)
-    end
-
-    defp do_format_keys(map) when is_map(map) do
-      Enum.reduce map, %{}, fn({k, v}, a) ->
-        Map.put_new(a, format_key(k), v)
-      end
-    end
-    defp do_format_keys(other), do: other
-
-    #TODO: Support custom de-serialization (eg, camelcase)
-    def format_key(key) do
-      case Application.get_env(:ja_serializer, :key_format, :dasherized) do
-        :dasherized -> dash_to_underscore(key)
-        :underscored -> key
-        _ -> key
-      end
-    end
-
-    defp dash_to_underscore(key), do: String.replace(key, ~r/-/, "_")
   end
 end

--- a/lib/ja_serializer/param_parser.ex
+++ b/lib/ja_serializer/param_parser.ex
@@ -1,0 +1,43 @@
+defprotocol JaSerializer.ParamParser do
+  @fallback_to_any true
+  def parse(params)
+end
+
+defimpl JaSerializer.ParamParser, for: Any do
+  def parse(data), do: data
+end
+
+defimpl JaSerializer.ParamParser, for: List do
+  def parse(list), do: Enum.map(list, &JaSerializer.ParamParser.format/1)
+end
+
+defimpl JaSerializer.ParamParser, for: [BitString, Integer, Float, Atom] do
+  def parse(data), do: data
+end
+
+if Code.ensure_loaded?(Plug) do
+  defimpl JaSerializer.ParamParser, for: Plug.Upload do
+    def parse(data), do: data
+  end
+end
+
+defimpl JaSerializer.ParamParser, for: Map do
+  def parse(map) do
+    Enum.reduce map, %{}, fn({key, val}, map) ->
+      key = JaSerializer.ParamParser.Utils.format_key(key)
+      Map.put(map, key, JaSerializer.ParamParser.parse(val))
+    end
+  end
+end
+
+defmodule JaSerializer.ParamParser.Utils do
+  def format_key(key) do
+    case Application.get_env(:ja_serializer, :key_format, :dasherized) do
+      :dasherized  -> dash_to_underscore(key)
+      :underscored -> key
+      _ -> key
+    end
+  end
+
+  defp dash_to_underscore(key), do: String.replace(key, "-", "_")
+end

--- a/test/ja_serializer/deserializer_test.exs
+++ b/test/ja_serializer/deserializer_test.exs
@@ -45,6 +45,9 @@ defmodule JaSerializer.DeserializerTest do
         "attributes" => %{
           "some-nonsense" => true,
           "foo-bar" => true,
+          "some-map" => %{
+            "nested-key" => "unaffected-values"
+          }
         }
       }
     })
@@ -54,6 +57,7 @@ defmodule JaSerializer.DeserializerTest do
     result = ExamplePlug.call(conn, [])
     assert result.params["data"]["attributes"]["some_nonsense"]
     assert result.params["data"]["attributes"]["foo_bar"]
+    assert result.params["data"]["attributes"]["some_map"]["nested_key"]
   end
 
   test "converts query param key names - dasherized" do

--- a/test/ja_serializer/param_parser_test.exs
+++ b/test/ja_serializer/param_parser_test.exs
@@ -1,0 +1,95 @@
+defmodule JaSerializer.ParamParserTest do
+  use ExUnit.Case
+
+  import JaSerializer.ParamParser, only: [parse: 1]
+
+  setup do
+    on_exit fn ->
+      Application.delete_env(:ja_serializer, :key_format)
+    end
+    :ok
+  end
+
+  test "attribute and relationship keys are converted" do
+    params = %{
+      "data" => %{
+        "type" => "example",
+        "id"   => "one",
+        "attributes" => %{
+          "some-nonsense" => true,
+          "foo-bar" => "unaffected-values",
+          "some-map" => %{
+            "nested-key" => "unaffected-values"
+          }
+        },
+        "relationships" => %{
+          "my-model" => %{
+            "links" => %{ "related" => "/api/my_model/1" },
+            "data" => %{ "type" => "my_model", "id" => "1" }
+          }
+        }
+      }
+    }
+    expected = %{
+      "data" => %{
+        "type" => "example",
+        "id"   => "one",
+        "attributes" => %{
+          "some_nonsense" => true,
+          "foo_bar" => "unaffected-values",
+          "some_map" => %{
+            "nested_key" => "unaffected-values"
+          }
+        },
+        "relationships" => %{
+          "my_model" => %{
+            "links" => %{ "related" => "/api/my_model/1" },
+            "data" => %{ "type" => "my_model", "id" => "1" }
+          }
+        }
+      }
+    }
+
+    assert parse(params) == expected
+
+    Application.put_env(:ja_serializer, :key_format, :underscored)
+
+    assert parse(params) == params
+  end
+
+  test "converts query param key names" do
+    params = %{
+      "page" => %{
+        "page-size" => "",
+      },
+      "filter" => %{
+        "foo-attr" => "val"
+      }
+    }
+
+    expected = %{
+      "page" => %{
+        "page_size" => "",
+      },
+      "filter" => %{
+        "foo_attr" => "val"
+      }
+    }
+
+    assert parse(params) == expected
+
+    Application.put_env(:ja_serializer, :key_format, :underscored)
+
+    assert parse(params) == params
+  end
+
+  test "uploads are not effected" do
+    params = %{
+      "foo-key" => %Plug.Upload{filename: "foo.bar"}
+    }
+    expected = %{
+      "foo_key" => %Plug.Upload{filename: "foo.bar"}
+    }
+    assert parse(params) == expected
+  end
+end


### PR DESCRIPTION
This allows anything parsed as a struct (eg from another plug or just because it has a __struct__ key passed along) to be implemented by the user.

@linstula @zipme.

I still am a bit unsure how this should really behave and looking for feedback, but I was thinking a protocol would be a super easy way to solve #69 and have an easy way to solve anything similar that comes up.

I am particularly unsure if nested maps in attributes should have their keys formatted. Thoughts?

I also haven't looked at any possible performance impact (anything passing through Any will be slow).