### PR TITLE
performance improvements when serializer contains included resources

### DIFF
--- a/lib/ja_serializer/builder/included.ex
+++ b/lib/ja_serializer/builder/included.ex
@@ -3,8 +3,17 @@ defmodule JaSerializer.Builder.Included do
 
   alias JaSerializer.Builder.ResourceObject
 
+  defp resource_key(resource) do
+    {resource.id, resource.type}
+  end
+
   def build(%{data: data} = context, primary_resources) when is_list(data) do
-    do_build(data, context, [], List.wrap(primary_resources))
+    known = List.wrap(primary_resources)
+    |> Enum.map(&resource_key/1)
+    |> Enum.into(HashSet.new)
+
+    do_build(data, context, %{}, known)
+    |> Map.values
   end
 
   def build(context, primary_resources) do
@@ -15,16 +24,13 @@ defmodule JaSerializer.Builder.Included do
 
   defp do_build([], _context, included, _known_resources), do: included
   defp do_build([struct | structs], context, included, known) do
-    context = Map.put(context, :data, struct)
-
-    new = context
-          |> relationships_with_include
-          |> Enum.flat_map(&resources_for_relationship(&1, context, included, known))
-          |> Enum.uniq(&({&1.id, &1.type}))
-          |> reject_known(included, known)
-
-    # Call for next struct
-    do_build(structs, context, (new ++ included), known)
+    context  = Map.put(context, :data, struct)
+    included = context
+    |> relationships_with_include
+    |> Enum.reduce(included, fn item, included ->
+      resources_for_relationship(item, context, included, known)
+    end)
+    do_build(structs, context, included, known)
   end
 
   defp resource_objects_for(structs, conn, serializer, fields) do
@@ -48,23 +54,24 @@ defmodule JaSerializer.Builder.Included do
 
   # Find resources for relationship & parent_context
   defp resources_for_relationship({_, name, opts}, context, included, known) do
-    context_opts = context[:opts]
-    new = apply(context.serializer, name, [context.data, context.conn])
-          |> List.wrap
-          |> resource_objects_for(context.conn, opts[:serializer], context_opts[:fields])
-          |> reject_known(included, known)
+    context_opts     = context[:opts]
+    {cont, included} = apply(context.serializer, name, [context.data, context.conn])
+    |> List.wrap
+    |> resource_objects_for(context.conn, opts[:serializer], context_opts[:fields])
+    |> Enum.reduce({[], included}, fn item, {cont, included} ->
+      key = resource_key(item)
+      if HashSet.member?(known, key) or Map.has_key?(included, key) do
+        {cont, included}
+      else
+        {[item.data | cont], Map.put(included, key, item)}
+      end
+    end)
 
     child_context = context
     |> Map.put(:serializer, opts[:serializer])
     |> Map.put(:opts, opts_with_includes_for_relation(context_opts, name))
 
-    new
-    |> Enum.map(&(&1.data))
-    |> do_build(child_context, (new ++ included), known)
-  end
-
-  defp reject_known(resources, included, primary) do
-    Enum.reject(resources, &(&1 in included || &1 in primary))
+    do_build(cont, child_context, included, known)
   end
 
   defp opts_with_includes_for_relation(opts, rel_name) do

--- a/test/bench.exs
+++ b/test/bench.exs
@@ -1,0 +1,76 @@
+defmodule Foo do
+  defstruct [:id, :bars]
+end
+
+defmodule Bar do
+  defstruct [:id, :foo]
+end
+
+defmodule BarSerializer do
+  use JaSerializer.Serializer
+
+  def type, do: "bar"
+
+  attributes []
+
+  has_one :foo,
+  serializer: FooSerializer
+end
+
+defmodule FooSerializer do
+  use JaSerializer.Serializer
+
+  def type, do: "foo"
+
+  attributes []
+
+  has_many :bars,
+  include: true,
+  serializer: BarSerializer
+end
+
+defmodule Benchmark do
+  def generate(a, b) do
+    for m <- 0..a do
+      bars = for n <- 0..b do
+        %Bar{id: n, foo: %Foo{id: m, bars: []}}
+      end
+      %Foo{id: m, bars: bars}
+    end
+  end
+
+  def tc_avg(mod, fun, args, iters \\ 10) do
+    {z, _} = :timer.tc(mod, fun, args)
+    {m, _} = Enum.reduce(0..iters, {z, 1}, fn _, {m, n} ->
+      IO.write :stderr, "."
+      {t, _} = :timer.tc(mod, fun, args)
+      {m + (t - m) / (n + 1), n + 1}
+    end)
+    IO.write :stderr, "\n"
+    m
+  end
+
+  def humanize(n) do
+    Enum.reduce_while(["ms", "s"], {n, "us"}, fn n_scale, {n, o_scale} ->
+      if n > 1000 do
+        {:cont, {n/1000, n_scale}}
+      else
+        {:halt, {n, o_scale}}
+      end
+    end)
+  end
+
+  defp parse_int!(n) do
+    case Integer.parse n, 10 do
+      {n, ""} -> n
+    end
+  end
+
+  def run do
+    [x, y] = System.argv |> Enum.map(&parse_int!/1)
+    tc_avg(FooSerializer, :format, [generate(x, y)], 25)
+    |> humanize
+  end
+end
+
+Benchmark.run |> IO.inspect

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -176,6 +176,8 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
       request_path: "/articles/"
     }
 
+    hashset = & Enum.into(&1, HashSet.new)
+
     results = ArticleSerializer.format(page, conn, [])
               |> Poison.encode!
               |> Poison.decode!(keys: :atoms)
@@ -183,9 +185,9 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     expected = Poison.decode!(@expected, keys: :atoms)
 
     assert results[:links] == expected[:links]
-    assert results[:included] == expected[:included]
+    assert hashset.(results[:included]) == hashset.(expected[:included])
     assert results[:data][:attributes] == expected[:data][:attributes]
     assert results[:data] == expected[:data]
-    assert results == expected
+    assert Map.delete(results, :included) == Map.delete(expected, :included)
   end
 end


### PR DESCRIPTION
To demonstrate the issue I've written a micro benchmark that
serializes N resources which contains a has_many association with
M elements each.

When I run it against the current codebase my machine gets the
following results:

```
# usage: mix run test/bench.exs N M
$ mix run test/bench.exs 50 50
.......................... # number of iterations
{455.94614814814815, "ms"}
```

After this patch I get the following:

```
$ mix run test/bench.exs 50 50
.......................... 
{14.883851851851853, "ms"}
```

The problem was using `++` to concatenate lists in a loop and using
a list to querying for membership.
