### PR TITLE
Allow Multiple Links for each Relationship

### DIFF
--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -17,10 +17,12 @@ defmodule JaSerializer.Builder.Relationship do
   end
 
   defp add_links(relation, {_type, _name, opts}, context) do
-    case opts[:link] do
-      nil ->  relation
-      path -> Map.put(relation, :links, [Link.build(context, :related, path)])
-    end
+    Keyword.get(opts, :links, [])
+      |> Enum.map(fn {key, path} -> Link.build(context, key, path) end)
+      |> case do
+        []   ->  relation
+        links -> Map.put(relation, :links, links)
+      end
   end
 
   defp add_data(relation, {_t, name, opts}, context) do

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -393,6 +393,14 @@ defmodule JaSerializer.Serializer do
       ])
     end
 
+    if opts[:link] do
+      updated =
+        Keyword.get(opts, :links, [])
+          |> Keyword.put_new(:related, opts[:link])
+
+      opts = Keyword.put(opts, :links, updated)
+    end
+
     case is_boolean(include) or is_nil(include) do
       true -> opts
       false ->

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -22,7 +22,13 @@ defmodule JaSerializer.Builder.RelationshipTest do
 
   defmodule FooSerializer do
     use JaSerializer
-    has_many :bars, type: "bar"
+    has_many :bars,
+             type: "bar",
+             links: [
+               self: "/foo/:id/relationships/bars",
+               related: "/foo/:id/bars"
+             ]
+
     has_one :baz, field: :baz_id, type: "baz"
     def bars(_,_), do: [1,2,3]
   end
@@ -53,6 +59,13 @@ defmodule JaSerializer.Builder.RelationshipTest do
     formatted_ids = Enum.map(comments[:data], &(&1.id))
     assert "c1" in formatted_ids
     assert "c2" in formatted_ids
+  end
+
+  test "building a self link Relationship is possible along with the 'related'" do
+    json = FooSerializer.format(%{baz_id: 1, id: 1})
+    rel_links = json.data.relationships["bars"].links
+    assert  "/foo/1/relationships/bars" = rel_links["self"]
+    assert  "/foo/1/bars" = rel_links["related"]
   end
 
   test "building relationships from ids works" do


### PR DESCRIPTION
## Overview

The JSON-API spec specifies that if a Relationship object includes
the `links` key it must have at least `self` or `related` as one of
it's link keys: http://jsonapi.org/format/#document-resource-object-relationships

The `link` option for the `has_one` and `has_many` relationships
under the serializer were forcing it to always be placed under the
`related` key.  This change allows you specify both the `related`
and `self` links - along with any abitrary key links you want to
have why still backwards supporting the `link` option.

## Oustanding Questions

Is this the right way to go about doing this?  If so I may need some
guidance on what I should change in README and internal comment
docs regarding this change.