### PR TITLE
Add Dynamic Type Functionality

### DIFF
--- a/lib/ja_serializer/builder/resource_object.ex
+++ b/lib/ja_serializer/builder/resource_object.ex
@@ -18,7 +18,7 @@ defmodule JaSerializer.Builder.ResourceObject do
   def build(%{serializer: serializer} = context) do
     %__MODULE__{
       id:            serializer.id(context.data, context.conn),
-      type:          serializer.type,
+      type:          __type(serializer.type, context),
       data:          context.data,
       attributes:    Attribute.build(context),
       relationships: Relationship.build(context),
@@ -26,4 +26,7 @@ defmodule JaSerializer.Builder.ResourceObject do
       meta:          serializer.meta(context.data, context.conn)
     }
   end
+
+  defp __type(type, context) when is_function(type), do: type.(context.data, context.conn)
+  defp __type(type, _), do: type
 end

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -71,8 +71,13 @@ defmodule JaSerializer.Serializer do
   To override simply define the type function:
 
       def type, do: "category"
+
+  You may also specify a dynamic type which recieves the data
+  and connection as parameters:
+
+      def type, do: fn(model, _conn) -> model.type end
   """
-  defcallback type() :: String.t
+  defcallback type() :: String.t | fun()
 
   @doc """
   Returns a map of attributes to be mapped.

--- a/test/ja_serializer/dynamic_type_test.exs
+++ b/test/ja_serializer/dynamic_type_test.exs
@@ -1,0 +1,22 @@
+defmodule JaSerializer.DynamicTypeTest do
+  use ExUnit.Case
+
+  defmodule AnimalSerialzer do
+    use JaSerializer.Serializer
+    attributes [:name]
+    def type, do: fn(animal, _conn) -> animal.type end
+  end
+
+  @wilbur %{name: "Wilbur", type: "pig"}
+  @charlotte %{name: "Charlotte", type: "spider"}
+
+  test "dynamically assigns the type for single item" do
+    wilbur = AnimalSerialzer.format(@wilbur)
+    assert wilbur.data.type == "pig"
+  end
+
+  test "works for multiple items" do
+    animals = AnimalSerialzer.format([@wilbur, @charlotte])
+    assert animals.data |> Enum.map(&(&1.type)) == ~w(pig spider)
+  end
+end


### PR DESCRIPTION
An object is considered unique by combining it's `id` with its `type`
in the JSON API spec: http://jsonapi.org/format/#document-resource-objects

> Within a given API, each resource object's type and id pair MUST
> identify a single, unique resource.

When presenting multiple "liked" items that could collide with each
other via the `id` this becomes a valueable tool to have one serializer
that can present all similar items and provide a more approriate `type`
so that each item can be considered unique.