### PR TITLE
Extend Dynamic Type Functionality to Relationships

### DIFF
--- a/lib/ja_serializer/builder/resource_identifier.ex
+++ b/lib/ja_serializer/builder/resource_identifier.ex
@@ -16,7 +16,7 @@ defmodule JaSerializer.Builder.ResourceIdentifier do
 
   defp do_build(data, type, context) do
     %__MODULE__{
-      type: type,
+      type: find_type(data, type, context),
       id: find_id(data, context)
     }
   end
@@ -30,4 +30,10 @@ defmodule JaSerializer.Builder.ResourceIdentifier do
   end
 
   defp find_id(id, _), do: id
+
+  defp find_type(data, type, context) when is_function(type) do
+    type.(data, context.conn)
+  end
+
+  defp find_type(_, type, _), do: type
 end

--- a/test/ja_serializer/dynamic_type_test.exs
+++ b/test/ja_serializer/dynamic_type_test.exs
@@ -1,14 +1,25 @@
 defmodule JaSerializer.DynamicTypeTest do
   use ExUnit.Case
 
+  @wilbur %{id: 1, name: "Wilbur", type: "pig"}
+  @charlotte %{id: 1, name: "Charlotte", type: "spider"}
+  @farm %{ id: 1,
+           name: "Green Acres",
+           animals: [@wilbur, @charlotte],
+           special_animal: @wilbur }
+
   defmodule AnimalSerialzer do
     use JaSerializer.Serializer
     attributes [:name]
     def type, do: fn(animal, _conn) -> animal.type end
   end
 
-  @wilbur %{name: "Wilbur", type: "pig"}
-  @charlotte %{name: "Charlotte", type: "spider"}
+  defmodule FarmSerialzer do
+    use JaSerializer.Serializer
+    attributes [:name]
+    has_many :animals, serializer: AnimalSerialzer
+    has_one :special_animal, serializer: AnimalSerialzer
+  end
 
   test "dynamically assigns the type for single item" do
     wilbur = AnimalSerialzer.format(@wilbur)
@@ -18,5 +29,17 @@ defmodule JaSerializer.DynamicTypeTest do
   test "works for multiple items" do
     animals = AnimalSerialzer.format([@wilbur, @charlotte])
     assert animals.data |> Enum.map(&(&1.type)) == ~w(pig spider)
+  end
+
+  test "works with 'has_many' relationship data" do
+    farm = FarmSerialzer.format(@farm)
+    animals = farm.data.relationships["animals"].data |> Enum.map(&(&1.type))
+    assert "pig" in animals
+    assert "spider" in animals
+  end
+
+  test "works with 'has_one' relationship data" do
+    farm = FarmSerialzer.format(@farm)
+    assert farm.data.relationships["special-animal"].data.type == "pig"
   end
 end


### PR DESCRIPTION
When specifing a Serializer for a `has_one` or `has_many` relationship,
it will now provide the correct dynamic relationship calculated by
the given fun.

Sorry @alanpeabody, I jumped the gun a bit and didn't realize that this change wouldn't trickle down to the relationships.  This change will shore up that short-fall.