### PR TITLE
When Scrivener page has 0 total pages only the self link should be rendered

### DIFF
--- a/lib/ja_serializer/builder/scrivener_links.ex
+++ b/lib/ja_serializer/builder/scrivener_links.ex
@@ -30,7 +30,7 @@ if Code.ensure_loaded?(Scrivener) do
     end
 
     defp next_pages({list, %{data: page} = context}) do
-      if page.page_number == page.total_pages do
+      if page.page_number == page.total_pages || page.total_pages == 0 do
         {list, context}
       else
         next = page.page_number + @first_page

--- a/test/ja_serializer/builder/scrivener_links_test.exs
+++ b/test/ja_serializer/builder/scrivener_links_test.exs
@@ -69,6 +69,22 @@ defmodule JaSerializer.Builder.ScrivenerLinksTest do
     assert Enum.sort([:self, :first, :prev]) == links
   end
 
+  test "when result contains no data, include only self link" do
+    page = %Scrivener.Page{
+      page_number: 1,
+      page_size: 20,
+      total_pages: 0
+    }
+    context = %{
+      data: page,
+      conn: %Plug.Conn{query_params: %{}},
+      serializer: PersonSerializer,
+      opts: []
+    }
+    links = ScrivenerLinks.build(context) |> Dict.keys |> Enum.sort
+    assert Enum.sort([:self]) == links
+  end
+
   test "url is taken from current conn url, params forwarded" do
     page = %Scrivener.Page{
       page_number: 30,


### PR DESCRIPTION
When the page object is passed into the scrivener builder it can have total_pages of 0 and page_number as 1. This is the case when there were no results returned by the query. In this case there should not be any next, last or previous links.