### PR TITLE
Adds param utility for merging attrs and relations.

### DIFF
--- a/lib/ja_serializer/params.ex
+++ b/lib/ja_serializer/params.ex
@@ -1,0 +1,71 @@
+defmodule JaSerializer.Params do
+  @moduledoc """
+  Functions to help when working with json api params.
+  """
+
+  @doc """
+  Takes the entire params passed in and merges relationships and attributes.
+
+  Note, this expects to recieve the json api "data" param.
+
+  Example functionality:
+
+      JaSerializer.Params.flatten(%{
+        "type" => "person",
+        "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
+        "relationships" => %{"user" => %{"data" => %{"id" => 1}}}
+      })
+      %{
+        "first" => "Jane",
+        "last" => "Doe",
+        "type" => "anon",
+        "user_id" => 1
+      }
+
+  Example usage:
+
+      def create(conn, %{"data" => data}) do
+        %Comment{}
+        |> Comment.changeset(create_params(data))
+        |> Repo.insert
+        |> case do
+          {:ok, my_model} ->
+            # etc
+          {:error, changeset} -> etc
+            # etc
+        end
+      end
+
+      defp create_params(data) do
+        data
+        |> JaSerializer.Params.to_attributes
+        |> Map.take(["name", "body", "post_id"])
+      end
+
+  """
+  def to_attributes(%{"data" => data}), do: to_attributes(data)
+  def to_attributes(data) when is_map(data) do
+    data
+    |> parse_relationships
+    |> Map.merge(data["attributes"] || %{})
+    |> Map.put_new("type", data["type"])
+  end
+
+  defp parse_relationships(%{"relationships" => nil}) do
+    %{}
+  end
+
+  defp parse_relationships(%{"relationships" => rels}) do
+    Enum.reduce rels, %{}, fn
+      ({_name, %{"data" => nil}}, rel) -> rel
+      ({name, %{"data" => %{"id" => id}}}, rel) ->
+        Map.put(rel, "#{name}_id", id)
+      ({name, %{"data" => ids}}, rel) when is_list(ids) ->
+        Map.put(rel, "#{name}_ids", Enum.map(ids, &(&1["id"])))
+    end
+  end
+
+  defp parse_relationships(_) do
+    %{}
+  end
+end

--- a/test/ja_serializer/params_test.exs
+++ b/test/ja_serializer/params_test.exs
@@ -1,0 +1,48 @@
+defmodule JaSerializer.ParamsTest do
+  use ExUnit.Case, async: true
+
+  import JaSerializer.Params, only: [to_attributes: 1]
+
+  test "no relationships" do
+    input = %{"data" => %{
+      "type" => "person",
+      "attributes" => %{"first" => "Jane", "last" => "Doe"}
+    }}
+    output = %{
+      "first" => "Jane",
+      "last" => "Doe",
+      "type" => "person"
+    }
+    assert to_attributes(input) == output
+  end
+
+  test "singular relationship" do
+    input = %{"data" => %{
+      "type" => "person",
+      "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
+      "relationships" => %{"user" => %{"data" => %{"id" => 1}}}
+    }}
+    output = %{
+      "first" => "Jane",
+      "last" => "Doe",
+      "type" => "anon",
+      "user_id" => 1
+    }
+    assert to_attributes(input) == output
+  end
+
+  test "plural relationships" do
+    input = %{"data" => %{
+      "type" => "person",
+      "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
+      "relationships" => %{"user" => %{"data" => [%{"id" => 1}, %{"id" => 2}]}}
+    }}
+    output = %{
+      "first" => "Jane",
+      "last" => "Doe",
+      "type" => "anon",
+      "user_ids" => [1, 2]
+    }
+    assert to_attributes(input) == output
+  end
+end


### PR DESCRIPTION
Does not handle whitelisting and keeps keys as strings to mitigate atom
overflow attacks.

@Dreamer009 this is a first step to allowing use of generators. I had initially thought about just generating "create_params" and "update_params" functions that manually generated the acceptable attributes, however I think you are correct and and a helper function to do this would be handy.

I ended up pulling in an implementation from JaResource because I wanted to address the atom issue as well as support multiple ids (many_to_many) and tweak the API to take the data json directly.

I am interested in feedback, in particular I am unsure if the name of the function really represents what it does, but `JaSerializer.Params.merge_attributes_and_relationships` seemed a little long.