### PR TITLE
add support for additional links on the resource [other than self]

### DIFF
--- a/lib/ja_serializer/builder/resource_object.ex
+++ b/lib/ja_serializer/builder/resource_object.ex
@@ -22,7 +22,7 @@ defmodule JaSerializer.Builder.ResourceObject do
       data:          context.data,
       attributes:    Attribute.build(context),
       relationships: Relationship.build(context),
-      links:         [Link.build(context, :self, serializer.__location)],
+      links:         Enum.map(serializer.__links, fn {type, uri} -> Link.build(context, type, uri) end),
       meta:          serializer.meta(context.data, context.conn)
     }
   end

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -142,12 +142,12 @@ defmodule JaSerializer.Serializer do
   defmacro __using__(_) do
     quote do
       @behaviour JaSerializer.Serializer
+      @links      []
       @attributes []
       @relations  []
-      @location   nil
 
       import JaSerializer.Serializer, only: [
-        serialize: 2, attributes: 1, location: 1,
+        serialize: 2, attributes: 1, location: 1, links: 1,
         has_many: 2, has_one: 2, has_many: 1, has_one: 1
       ]
 
@@ -261,7 +261,13 @@ defmodule JaSerializer.Serializer do
   """
   defmacro location(uri) do
     quote bind_quoted: [uri: uri] do
-      @location uri
+      @links [{:self, uri} | @links]
+    end
+  end
+
+  defmacro links(links) do
+    quote bind_quoted: [links: links] do
+      @links (links ++ @links)
     end
   end
 
@@ -425,8 +431,8 @@ defmodule JaSerializer.Serializer do
   @doc false
   defmacro __before_compile__(_env) do
     quote do
+      def __links,      do: @links
       def __relations,  do: @relations
-      def __location,   do: @location
       def __attributes, do: @attributes
 
       def format(data) do


### PR DESCRIPTION
objective
=========

Allow users to define additional links [besides the self link] on the
resource. For example:

```
  {"data": {"links": {"foo": "/foo",
                      "bar": "/bar"
                     }
           }
  }
```

Currently there is the `location` macro but that creates the `self`
entry only.

changes
=======

In this PR I've added a new macro `links` which works like location
but allows you to name the links. The `location` macro continues
to work and can even be used together. All tests continue to work 
without modification and
I've included a couple of additional tests on
`test/ja_serializer/json_api_spec/links_and_location_test.exs`
[I couldn't find a better place]. An example of serializer using the
new syntax:

```
  defmodule FooSerializer do
    links [ self: "/foo",
            permalink: "/foo?19700101000000+00:00"
          ]
  end
```