### PR TITLE
Update to Ecto 2.0.0-rc

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,11 +22,11 @@ defmodule JaSerializer.Mixfile do
   defp deps do
     [{:inflex, "~> 1.4"},
      {:plug, "> 1.0.0"},
-     {:ecto, "> 1.0.0"},
+     {:ecto, "~> 2.0.0-rc"},
      {:poison, "~> 1.4 or ~> 2.0"},
      {:earmark, "~> 0.1", only: :dev},
      {:inch_ex, "~> 0.4", only: :docs},
-     {:scrivener, "~> 1.0", optional: true},
+     {:scrivener, git: "https://github.com/cultureamp/scrivener.git", branch: "update-to-ecto-2.0.0-rc"},
      {:benchfella, "~> 0.3.0", only: :dev},
      {:ex_doc, "~> 0.7", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,11 @@
 %{"benchfella": {:hex, :benchfella, "0.3.2", "b9648e77fa8d8b8b9fe8f54293bee63f7de03909b3af6ab22a0e546716a396fb", [:mix], []},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ecto": {:hex, :ecto, "1.1.5", "5c181b737a650117466b0540aa323198a0fb9d518e52718ac2c299f4047187e1", [:mix], [{:sbroker, "~> 0.7", [hex: :sbroker, optional: true]}, {:postgrex, "~> 0.11.0", [hex: :postgrex, optional: true]}, {:poolboy, "~> 1.4", [hex: :poolboy, optional: false]}, {:poison, "~> 1.0", [hex: :poison, optional: true]}, {:mariaex, "~> 0.5.0 or ~> 0.6.0", [hex: :mariaex, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "ecto": {:hex, :ecto, "2.0.0-rc.5", "a95184a260edb89669be7746b3b270725ce6940e378b05d19df82eecf52544cb", [:mix], [{:sbroker, "~> 0.7", [hex: :sbroker, optional: true]}, {:postgrex, "~> 0.11.1", [hex: :postgrex, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:mariaex, "~> 0.7.1", [hex: :mariaex, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "inch_ex": {:hex, :inch_ex, "0.4.0", "27829de2227edfba8fa5c431088578685c0956128b40522957077963e563e868", [:mix], [{:poison, "~> 1.2", [hex: :poison, optional: false]}]},
   "inflex": {:hex, :inflex, "1.4.1", "7b7aedff806f43a43c21b6ef9ae5c83ed9c1322cf80f1935882856bcd1aa87c6", [:mix], []},
   "plug": {:hex, :plug, "1.1.4", "2eee0e85ad420db96e075b3191d3764d6fff61422b101dc5b02e9cce99cacfc7", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "scrivener": {:hex, :scrivener, "1.0.0", "2c4311811d5f1dca954cfc2da6d9b466962bfe7fcfb74acfb8dc6f29b1f0d48b", [:mix], [{:ecto, "~> 1.0", [hex: :ecto, optional: false]}]}}
+  "scrivener": {:git, "https://github.com/cultureamp/scrivener.git", "305491e29fba11f0587fee588c3f6cbeb7002edd", [branch: "update-to-ecto-2.0.0-rc"]}}

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -34,7 +34,8 @@ defmodule JaSerializer.EctoErrorSerializerTest do
       Ecto.Changeset.add_error(
         %Ecto.Changeset{},
         :monies,
-        {"must be more then %{count}", [count: 10]}
+        "must be more then %{count}",
+        count: 10,
       )
     )
   end


### PR DESCRIPTION
Adds support for Ecto 2.0.0-rc as discussed in #112. As this uses a fork of scrivener, I would not recommend merging, but this might be of use to folks wishing to experiment with the release candidate.