### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ JaSerializer
 
 [![Build Status](https://travis-ci.org/AgilionApps/ja_serializer.svg?branch=master)](https://travis-ci.org/AgilionApps/ja_serializer)
 [![Hex Version](https://img.shields.io/hexpm/v/ja_serializer.svg)](https://hex.pm/packages/ja_serializer)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/AgilionApps/ja_serializer.svg)](https://beta.hexfaktor.org/github/AgilionApps/ja_serializer)
 [![Inline docs](http://inch-ci.org/github/AgilionApps/ja_serializer.svg)](http://inch-ci.org/github/AgilionApps/ja_serializer)
 
 jsonapi.org formatting of Elixir data structures suitable for serialization by


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/AgilionApps/ja_serializer.svg)](https://beta.hexfaktor.org/github/AgilionApps/ja_serializer) [![Inline docs](http://inch-ci.org/github/AgilionApps/ja_serializer.svg?branch=master)](http://inch-ci.org/github/AgilionApps/ja_serializer)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think about this idea!