### PR TITLE
Fixed documentation that referenced non-existent `flatten`

### DIFF
--- a/lib/ja_serializer/params.ex
+++ b/lib/ja_serializer/params.ex
@@ -10,7 +10,7 @@ defmodule JaSerializer.Params do
 
   Example functionality:
 
-      JaSerializer.Params.flatten(%{
+      JaSerializer.Params.to_attributes(%{
         "type" => "person",
         "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
         "relationships" => %{"user" => %{"data" => %{"id" => 1}}}


### PR DESCRIPTION
I can't find a function named `flatten` in the codebase so I'm guessing that the docs are what are wrong.