### PR TITLE
Change callback type/0 to type/2.

### DIFF
--- a/lib/ja_serializer/builder/attribute.ex
+++ b/lib/ja_serializer/builder/attribute.ex
@@ -13,9 +13,9 @@ defmodule JaSerializer.Builder.Attribute do
     serializer.attributes(data, conn)
   end
 
-  defp filter_fields(attrs, %{serializer: serializer, opts: opts}) do
+  defp filter_fields(attrs, context = %{serializer: serializer, opts: opts}) do
     case opts[:fields] do
-      fields when is_map(fields) -> do_filter(attrs, fields[serializer.type])
+      fields when is_map(fields) -> do_filter(attrs, fields[serializer.type(context.data, context.conn)])
       _any -> attrs
     end
   end

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -26,19 +26,17 @@ defmodule JaSerializer.Builder.Relationship do
   end
 
   defp add_data(relation, definition, context) do
-    case determine_type(definition) do
-      nil  -> relation
-      type ->
-        context = Map.put(context, :resource_serializer, definition.serializer)
-        Map.put(relation, :data, ResourceIdentifier.build(context, type, definition))
+    if should_have_identifiers?(definition, context) do
+      Map.put(relation, :data, ResourceIdentifier.build(context, definition))
+    else
+      relation
     end
   end
 
-  defp determine_type(definition) do
-    case {definition.type, definition.serializer} do
-      {nil, nil}        -> nil
-      {nil, serializer} -> apply(serializer, :type, [])
-      {type, _}         -> type
-    end
+  defp should_have_identifiers?(%{type: nil, serializer: nil}, _context), do: false
+  defp should_have_identifiers?(%{type: nil, serializer: _serializer}, _context) do
+    # TODO, there should be some way to have this optionally included.
+    true
   end
+  defp should_have_identifiers?(_definition, _context), do: true
 end

--- a/lib/ja_serializer/builder/resource_identifier.ex
+++ b/lib/ja_serializer/builder/resource_identifier.ex
@@ -3,12 +3,12 @@ defmodule JaSerializer.Builder.ResourceIdentifier do
 
   defstruct [:id, :type, :meta]
 
-  def build(context, type, definition) do
+  def build(context, definition) do
     case get_data(context, definition) do
       [] -> [:empty_relationship]
       nil -> :empty_relationship
-      many when is_list(many) -> Enum.map(many, &do_build(&1, type, context))
-      one -> do_build(one, type, context)
+      many when is_list(many) -> Enum.map(many, &do_build(&1, context, definition))
+      one -> do_build(one, context, definition)
     end
   end
 
@@ -19,26 +19,33 @@ defmodule JaSerializer.Builder.ResourceIdentifier do
   end
   defp get_data(_, %{data: data}), do: data
 
-  defp do_build(data, type, context) do
+  defp do_build(data, context, definition) do
     %__MODULE__{
-      type: find_type(data, type, context),
-      id: find_id(data, context)
+      type: find_type(data, context, definition),
+      id: find_id(data, context, definition)
     }
   end
 
-  defp find_id(%{} = data, %{resource_serializer: nil}) do
+  defp find_id(%{} = data, _context, %{serializer: nil}) do
     Map.get(data, :id)
   end
+  defp find_id(%{} = data, context, %{serializer: serializer}) do
+    serializer.id(data, context.conn)
+  end
+  defp find_id(id, _, _), do: id
 
-  defp find_id(%{} = data, context = %{resource_serializer: serializer}) do
-    apply(serializer, :id, [data, context.conn])
+  defp find_type(_data, _context, %{type: type, serializer: nil}), do: type
+  defp find_type(data, context, %{serializer: serializer}) do
+    case serializer.type(data, context.conn) do
+      type_fun when is_function(type_fun) ->
+        IO.write :stderr, IO.ANSI.format([:red, :bright,
+          "warning: returning an anonymous function from type/0 is " <>
+          "deprecated. Please use the `type/2` callback instead.\n" <>
+          Exception.format_stacktrace()
+        ])
+        type_fun.(data, context.conn)
+      type -> type
+    end
   end
 
-  defp find_id(id, _), do: id
-
-  defp find_type(data, type, context) when is_function(type) do
-    type.(data, context.conn)
-  end
-
-  defp find_type(_, type, _), do: type
 end

--- a/lib/ja_serializer/builder/resource_object.ex
+++ b/lib/ja_serializer/builder/resource_object.ex
@@ -18,7 +18,7 @@ defmodule JaSerializer.Builder.ResourceObject do
   def build(%{serializer: serializer} = context) do
     %__MODULE__{
       id:            serializer.id(context.data, context.conn),
-      type:          __type(serializer.type, context),
+      type:          __type(serializer.type(context.data, context.conn), context),
       data:          context.data,
       attributes:    Attribute.build(context),
       relationships: Relationship.build(context),

--- a/lib/ja_serializer/dsl.ex
+++ b/lib/ja_serializer/dsl.ex
@@ -315,7 +315,7 @@ defmodule JaSerializer.DSL do
   struct.
 
   In the comments example when a `serializer` plus `include: false` options are
-  used the `id/2` and `type/0` functions are called on the defined serializer.
+  used the `id/2` and `type/2` functions are called on the defined serializer.
 
   In the tags example where just the `type` option is used the `id` field is
   automatically used on each map/struct returned by the data source.

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -5,7 +5,7 @@ defmodule JaSerializer.Serializer do
   The following callbacks are available:
 
     * `id/2` - Return ID of struct to be serialized.
-    * `type/0` - Return string type of struct to beserialized.
+    * `type/2` - Return string type of struct to be serialized.
     * `attributes/2` - A map of attributes to serialized.
     * `relationships/2`- A map of `HasMany` and `HasOne` data structures.
     * `links/2` - A keyword list of any links pertaining to this struct.
@@ -70,15 +70,9 @@ defmodule JaSerializer.Serializer do
 
   To override simply define the type function:
 
-      def type, do: "category"
-
-  You may also specify a dynamic type which recieves the data
-  and connection as parameters:
-
-      def type, do: fn(model, _conn) -> model.type end
+      def type(_post,_conn), do: "category"
   """
-  # TODO: Can we convert this to type/2 for consistency without too much hassle?
-  defcallback type() :: String.t | fun()
+  defcallback type(map, Plug.Conn.t) :: String.t
 
   @doc """
   Returns a map of attributes to be serialized.
@@ -181,7 +175,8 @@ defmodule JaSerializer.Serializer do
             |> JaSerializer.Formatter.Utils.format_type
     quote do
       def type, do: unquote(type)
-      defoverridable [type: 0]
+      def type(_data, _conn), do: type()
+      defoverridable [type: 2, type: 0]
     end
   end
 

--- a/test/ja_serializer/formatter/attribute_test.exs
+++ b/test/ja_serializer/formatter/attribute_test.exs
@@ -8,7 +8,7 @@ defmodule JaSerializer.Formatter.AttributeTest do
   end
 
   defmodule SimpleSerializer do
-    def type, do: "simple"
+    def type(_,_), do: "simple"
     def attributes(data,_), do: data
   end
 


### PR DESCRIPTION
type/0 will continue to work if defined, however type/2 now perfered.
type/0 returning an anonymous function with arity of 2 is deprecated.

This is more consistent and all callbacks are now an arity of two and
accept the data structure and the conn.