### PR TITLE
Allow un-included includable relations w/o data

### DIFF
--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -10,7 +10,8 @@ defmodule JaSerializer.Builder.Relationship do
     Enum.map serializer.relationships(data, conn), &(build(&1, context))
   end
 
-  defp build({name, definition}, context) do
+  def build({name, definition}, context) do
+    definition = Map.put(definition, :name, name)
     %__MODULE__{name: name}
     |> add_links(definition, context)
     |> add_data(definition, context)
@@ -33,10 +34,16 @@ defmodule JaSerializer.Builder.Relationship do
     end
   end
 
-  defp should_have_identifiers?(%{type: nil, serializer: nil}, _context), do: false
-  defp should_have_identifiers?(%{type: nil, serializer: _serializer}, _context) do
-    # TODO, there should be some way to have this optionally included.
-    true
+  defp should_have_identifiers?(%{type: nil, serializer: nil}, _c),
+    do: false
+  defp should_have_identifiers?(%{type: _t, serializer: nil}, _c),
+    do: true
+  defp should_have_identifiers?(%{serializer: _s, identifiers: :always}, _c),
+    do: true
+  defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name}, context) do
+    case context[:opts][:include] do
+      nil -> true
+      includes -> is_list(includes[name])
+    end
   end
-  defp should_have_identifiers?(_definition, _context), do: true
 end

--- a/lib/ja_serializer/builder/top_level.ex
+++ b/lib/ja_serializer/builder/top_level.ex
@@ -20,8 +20,8 @@ defmodule JaSerializer.Builder.TopLevel do
   end
 
   def build(context) do
-    data = ResourceObject.build(context)
     context = Map.put(context, :opts, normalize_opts(context[:opts]))
+    data = ResourceObject.build(context)
     %__MODULE__{}
     |> Map.put(:data, data)
     |> Map.put(:included, Included.build(context, data))

--- a/lib/ja_serializer/dsl.ex
+++ b/lib/ja_serializer/dsl.ex
@@ -332,8 +332,8 @@ defmodule JaSerializer.DSL do
       defmodule MyApp.PostView do
         use JaSerializer
 
-        has_many :comments, serializer: MyApp.CommentView, include: true
-        has_many :tags,     serializer: MyApp.TagView,     include: true
+        has_many :comments, serializer: MyApp.CommentView, include: true, identifiers: :when_included
+        has_many :tags,     serializer: MyApp.TagView,     include: true, identifiers: :always
         has_many :author,   serializer: MyApp.AuthorView,  include: true, field: :created_by
 
         # ...
@@ -349,6 +349,10 @@ defmodule JaSerializer.DSL do
   option allows clients to include only the relationships they want.
   JaSerializer handles the serialization of this for you, however you will have
   to handle intellegent preloading of relationships yourself.
+
+  When a relationship is not loaded via includes the `identifiers` option will
+  be used to determine if Resorce Identifiers should be serialized or not. The
+  `identifiers` options accepts the atoms `:when_included` and `:always`.
 
   When specifying the include param, only the relationship requested will be
   included. For example, to only include the author and comments:

--- a/lib/ja_serializer/relationship.ex
+++ b/lib/ja_serializer/relationship.ex
@@ -29,42 +29,50 @@ defmodule JaSerializer.Relationship do
 
   defmodule HasMany do
     defstruct [
-      links:      [],
-      type:       nil,
-      serializer: nil,
-      include:    false,
-      data:       nil
+      links:       [],
+      type:        nil,
+      serializer:  nil,
+      include:     false,
+      data:        nil,
+      identifiers: :when_included,
+      name:        nil
     ]
 
     @doc false
     def from_dsl(name, dsl_opts) do
       %__MODULE__{
-        links:      dsl_opts[:links] || [],
-        type:       dsl_opts[:type],
-        serializer: dsl_opts[:serializer],
-        include:    dsl_opts[:include],
-        data:       dsl_opts[:data] || name
+        links:       dsl_opts[:links] || [],
+        type:        dsl_opts[:type],
+        serializer:  dsl_opts[:serializer],
+        include:     dsl_opts[:include],
+        data:        dsl_opts[:data] || name,
+        identifiers: dsl_opts[:identifiers] || :when_included,
+        name:        name
       }
     end
   end
 
   defmodule HasOne do
     defstruct [
-      links:      [],
-      type:       nil,
-      serializer: nil,
-      include:    false,
-      data:       nil
+      links:       [],
+      type:        nil,
+      serializer:  nil,
+      include:     false,
+      data:        nil,
+      identifiers: :always,
+      name:        nil
     ]
 
     @doc false
     def from_dsl(name, dsl_opts) do
       %__MODULE__{
-        links:      dsl_opts[:links] || [],
-        type:       dsl_opts[:type],
-        serializer: dsl_opts[:serializer],
-        include:    dsl_opts[:include],
-        data:       dsl_opts[:data] || name
+        links:       dsl_opts[:links] || [],
+        type:        dsl_opts[:type],
+        serializer:  dsl_opts[:serializer],
+        include:     dsl_opts[:include],
+        data:        dsl_opts[:data] || name,
+        identifiers: dsl_opts[:identifiers] || :always,
+        name:        name
       }
     end
   end


### PR DESCRIPTION
Adds `identifiers` to the relationship options that controls if
identifiers are included when a relationship is not included.

This would address: #45 & #103 