### PR TITLE
Deprecate MyMod.format/3 for JaSerializer.format/4

### DIFF
--- a/lib/ja_serializer.ex
+++ b/lib/ja_serializer.ex
@@ -47,4 +47,16 @@ defmodule JaSerializer do
       end
     end
   end
+
+  @doc """
+  Main serialization method.
+
+  Accepts a module implementing the JaSerializer.Serializer behaviour, data,
+  the conn and opts and returns a map ready for json encoding.
+  """
+  def format(serializer, data, conn \\ %{}, opts \\ []) do
+    %{data: data, conn: conn, serializer: serializer, opts: opts}
+    |> JaSerializer.Builder.build
+    |> JaSerializer.Formatter.format
+  end
 end

--- a/lib/ja_serializer/phoenix_view.ex
+++ b/lib/ja_serializer/phoenix_view.ex
@@ -79,7 +79,7 @@ defmodule JaSerializer.PhoenixView do
   """
   def render(serializer, data) do
     struct = find_struct(serializer, data)
-    serializer.format(struct, data[:conn], data[:opts] || [])
+    JaSerializer.format(serializer, struct, data[:conn], data[:opts] || [])
   end
 
   @doc """

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -226,9 +226,12 @@ defmodule JaSerializer.Serializer do
       end
 
       def format(data, conn, opts) do
-        %{data: data, conn: conn, serializer: __MODULE__, opts: opts}
-        |> JaSerializer.Builder.build
-        |> JaSerializer.Formatter.format
+        IO.write :stderr, IO.ANSI.format([:red, :bright,
+          "warning: #{__MODULE__}.format/3 is deprecated.\n" <>
+          "Please use JaSerializer.format/4 instead, eg:\n" <>
+          "JaSerializer.format(#{__MODULE__}, data, conn, opts)\n"
+        ])
+        JaSerializer.format(__MODULE__, data, conn, opts)
       end
     end
   end

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -88,7 +88,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert [_,_,_,_] = includes
 
     # Formatted
-    json = ArticleSerializer.format(a1)
+    json = JaSerializer.format(ArticleSerializer, a1)
     assert %{} = json[:data]
     assert [_,_,_,_] = json[:included]
   end
@@ -110,7 +110,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert "c2" in ids
 
     # Formatted
-    json = ArticleSerializer.format(a1)
+    json = JaSerializer.format(ArticleSerializer, a1)
     assert %{} = json[:data]
     assert [_,_,_] = json[:included]
   end
@@ -128,7 +128,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert "c1" in ids
 
     # Formatted
-    json = ArticleSerializer.format(a1)
+    json = JaSerializer.format(ArticleSerializer, a1)
     assert %{} = json[:data]
     assert [_] = json[:included]
   end
@@ -152,7 +152,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert "p1" in ids
 
     # Formatted
-    json = OptionalIncludeArticleSerializer.format(a1, %{}, include: "author")
+    json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "author")
     assert %{} = json[:data]
     assert [_] = json[:included]
 
@@ -180,7 +180,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert "c2" in ids
 
     # Formatted
-    json = OptionalIncludeArticleSerializer.format(a1, %{}, include: "author,comments.author")
+    json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "author,comments.author")
     assert %{} = json[:data]
     assert [_,_,_,_] = json[:included]
   end
@@ -205,7 +205,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert "t2" in ids
 
     # Formatted
-    json = OptionalIncludeArticleSerializer.format(a1, %{}, include: "tags,comments.author,comments.tags")
+    json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "tags,comments.author,comments.tags")
     assert %{} = json[:data]
     assert [_,_,_,_] = json[:included]
   end
@@ -227,7 +227,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert [_] = person.attributes
 
     # Formatted
-    json = ArticleSerializer.format(a1, %{}, fields: fields)
+    json = JaSerializer.format(ArticleSerializer, a1, %{}, fields: fields)
     assert %{attributes: formatted_attrs} = json[:data]
     article_attrs = Map.keys(formatted_attrs)
     assert [_] = article_attrs
@@ -255,7 +255,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert [_,_] = person.attributes
 
     # Formatted
-    json = ArticleSerializer.format(a1, %{}, fields: fields)
+    json = JaSerializer.format(ArticleSerializer, a1, %{}, fields: fields)
     assert [formatted_person] = json[:included]
     person_attrs = Map.keys(formatted_person[:attributes])
     assert [_,_] = person_attrs

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -54,7 +54,7 @@ defmodule JaSerializer.Builder.RelationshipTest do
     assert "c2" in ids
 
     # Formatted
-    json = ArticleSerializer.format(a1)
+    json = JaSerializer.format(ArticleSerializer, a1)
     assert %{relationships: %{"comments" => comments}} = json[:data]
     assert [_,_] = comments[:data]
 
@@ -64,14 +64,14 @@ defmodule JaSerializer.Builder.RelationshipTest do
   end
 
   test "building a self link Relationship is possible along with the 'related'" do
-    json = FooSerializer.format(%{baz_id: 1, id: 1})
+    json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1})
     rel_links = json.data.relationships["bars"].links
     assert  "/foo/1/relationships/bars" = rel_links["self"]
     assert  "/foo/1/bars" = rel_links["related"]
   end
 
   test "building relationships from ids works" do
-    json = FooSerializer.format(%{baz_id: 1, id: 1})
+    json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1})
     assert %{relationships: %{"bars" => bars, "baz" => baz}} = json[:data]
     assert baz.data.id == "1"
     assert [bar, _, _ ] = bars.data

--- a/test/ja_serializer/builder/resource_object_test.exs
+++ b/test/ja_serializer/builder/resource_object_test.exs
@@ -18,7 +18,7 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
     assert [_,_] = attributes
 
     # Formatted
-    json = ArticleSerializer.format(a1)
+    json = JaSerializer.format(ArticleSerializer, a1)
 
     assert %{attributes: attributes} = json[:data]
     fields = Map.keys(attributes)
@@ -37,7 +37,7 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
     assert [_] = attributes
 
     # Formatted
-    json = ArticleSerializer.format(a1, %{}, fields: fields)
+    json = JaSerializer.format(ArticleSerializer, a1, %{}, fields: fields)
 
     assert %{attributes: attributes} = json[:data]
     fields = Map.keys(attributes)

--- a/test/ja_serializer/dynamic_type_test.exs
+++ b/test/ja_serializer/dynamic_type_test.exs
@@ -8,38 +8,38 @@ defmodule JaSerializer.DynamicTypeTest do
            animals: [@wilbur, @charlotte],
            special_animal: @wilbur }
 
-  defmodule AnimalSerialzer do
+  defmodule AnimalSerializer do
     use JaSerializer
     attributes [:name]
     def type, do: fn(animal, _conn) -> animal.type end
   end
 
-  defmodule FarmSerialzer do
+  defmodule FarmSerializer do
     use JaSerializer
     attributes [:name]
-    has_many :animals, serializer: AnimalSerialzer
-    has_one :special_animal, serializer: AnimalSerialzer
+    has_many :animals, serializer: AnimalSerializer
+    has_one :special_animal, serializer: AnimalSerializer
   end
 
   test "dynamically assigns the type for single item" do
-    wilbur = AnimalSerialzer.format(@wilbur)
+    wilbur = JaSerializer.format(AnimalSerializer, @wilbur)
     assert wilbur.data.type == "pig"
   end
 
   test "works for multiple items" do
-    animals = AnimalSerialzer.format([@wilbur, @charlotte])
+    animals = JaSerializer.format(AnimalSerializer, [@wilbur, @charlotte])
     assert animals.data |> Enum.map(&(&1.type)) == ~w(pig spider)
   end
 
   test "works with 'has_many' relationship data" do
-    farm = FarmSerialzer.format(@farm)
+    farm = JaSerializer.format(FarmSerializer, @farm)
     animals = farm.data.relationships["animals"].data |> Enum.map(&(&1.type))
     assert "pig" in animals
     assert "spider" in animals
   end
 
   test "works with 'has_one' relationship data" do
-    farm = FarmSerialzer.format(@farm)
+    farm = JaSerializer.format(FarmSerializer, @farm)
     assert farm.data.relationships["special-animal"].data.type == "pig"
   end
 end

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -222,7 +222,7 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
   test "it serializes properly via the DSL", %{page: page, conn: conn} do
     hashset = & Enum.into(&1, HashSet.new)
 
-    results = ArticleSerializer.format(page, conn, [])
+    results = JaSerializer.format(ArticleSerializer, page, conn, [])
               |> Poison.encode!
               |> Poison.decode!(keys: :atoms)
 
@@ -238,7 +238,7 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
   test "it serializes properly via the behaviour", %{page: page, conn: conn} do
     hashset = & Enum.into(&1, HashSet.new)
 
-    results = PostSerializer.format(page, conn, [])
+    results = JaSerializer.format(PostSerializer, page, conn, [])
               |> Poison.encode!
               |> Poison.decode!(keys: :atoms)
 

--- a/test/ja_serializer/json_api_spec/resource_object_test.exs
+++ b/test/ja_serializer/json_api_spec/resource_object_test.exs
@@ -89,8 +89,7 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
   end
 
   test "it serializes properly using DSL", %{article: article} do
-    results = article
-              |> ArticleSerializer.format(%{}, meta: %{copyright: 2015})
+    results = JaSerializer.format(ArticleSerializer, article, %{}, meta: %{copyright: 2015})
               |> Poison.encode!
               |> Poison.decode!(keys: :atoms)
 
@@ -98,8 +97,7 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
   end
 
   test "it serializes properly using behaviour", %{article: article} do
-    results = article
-              |> PostSerializer.format(%{}, meta: %{copyright: 2015})
+    results = JaSerializer.format(PostSerializer, article, %{}, meta: %{copyright: 2015})
               |> Poison.encode!
               |> Poison.decode!(keys: :atoms)
 


### PR DESCRIPTION
Previously we were defining a function on the module that was not a
callback default. We should not do that, so lets deprecate for removal
in 1.0.

Instead we use `JaSerializer.format(MyMod, data, conn, opts)`