### PR TITLE
Add 'use JaResources' to scaffold controller

### DIFF
--- a/priv/templates/ja_serializer.gen.phoenix_api/controller.ex
+++ b/priv/templates/ja_serializer.gen.phoenix_api/controller.ex
@@ -1,5 +1,6 @@
 defmodule <%= module %>Controller do
   use <%= base %>.Web, :controller
+  use JaResource
 
   alias <%= module %>
   alias JaSerializer.Params


### PR DESCRIPTION
The generated scaffold controller is missing 'use JaResource'