### PR TITLE
Update Phoenix controller generator to use recommended error rendering

### DIFF
--- a/priv/templates/ja_serializer.gen.phoenix_api/controller.ex
+++ b/priv/templates/ja_serializer.gen.phoenix_api/controller.ex
@@ -23,7 +23,7 @@ defmodule <%= module %>Controller do
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> render(<%= base %>.ChangesetView, "error.json-api", changeset: changeset)
+        |> render(:errors, data: changeset)
     end
   end
 
@@ -42,7 +42,7 @@ defmodule <%= module %>Controller do
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> render(<%= base %>.ChangesetView, "error.json-api", changeset: changeset)
+        |> render(:errors, data: changeset)
     end
   end
 


### PR DESCRIPTION
Rendering with the ChangesetView did not display the errors in the correct JsonApi format. Now it does!

(thanks for the help, Alan!)