### PR TITLE
Change the inclusion behavior when include is nil

### DIFF
--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -40,9 +40,15 @@ defmodule JaSerializer.Builder.Relationship do
     do: true
   defp should_have_identifiers?(%{serializer: _s, identifiers: :always}, _c),
     do: true
+  defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name, include: true}, context) do
+    case context[:opts][:include] do
+      nil  -> true
+      includes -> is_list(includes[name])
+    end
+  end
   defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name}, context) do
     case context[:opts][:include] do
-      nil -> true
+      nil  -> false
       includes -> is_list(includes[name])
     end
   end

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -88,10 +88,11 @@ defmodule JaSerializer.Builder.RelationshipTest do
     assert [_ri1, _ri2, _ri3] = rel.data
   end
 
-  test "identifiers are included if serializer is passed in" do
+  test "identifiers are included if serializer is passed in and include is true" do
     comments = %HasMany{
       serializer: CommentSerializer,
-      data: [1,2,3]
+      data: [1,2,3],
+      include: true
     }
     context = %{conn: %{}, opts: []}
     rel = Relationship.build({:comments, comments}, context)
@@ -120,12 +121,21 @@ defmodule JaSerializer.Builder.RelationshipTest do
     assert [_ri1, _ri2, _ri3] = rel.data
   end
 
-  test "identifiers are not included if the serializer is passed in & name is not in include parama & identifiers is when_included" do
+  test "identifiers are not included if the serializer is passed in & name is not in include param & include is true & identifiers is when_included" do
     comments = %HasMany{
       serializer: CommentSerializer,
       identifiers: :when_included
     }
     context = %{conn: %{}, opts: [include: [:author]]}
+    rel = Relationship.build({:comments, comments}, context)
+  end
+
+  test "identifiers are not included if the serializer is passed in, there are not in include params & indentifiers is when_included" do
+    comments = %HasMany{
+      serializer: CommentSerializer,
+      identifiers: :when_included
+    }
+    context = %{conn: %{}, opts: []}
     rel = Relationship.build({:comments, comments}, context)
     assert rel.data == nil
   end

--- a/test/ja_serializer/dynamic_type_test.exs
+++ b/test/ja_serializer/dynamic_type_test.exs
@@ -17,7 +17,7 @@ defmodule JaSerializer.DynamicTypeTest do
   defmodule FarmSerializer do
     use JaSerializer
     attributes [:name]
-    has_many :animals, serializer: AnimalSerializer
+    has_many :animals, serializer: AnimalSerializer, identifiers: :always
     has_one :special_animal, serializer: AnimalSerializer
   end
 


### PR DESCRIPTION
When include is nil and the relationship is not in the include param the
identifiers are not included unless `indentifiers: :always` option is
set.

Fixes the second half of #130