### PR TITLE
Don't rely on package version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mix.deps
 defp deps do
   [
     # ...
-      {:ja_serializer, "~> 0.9.0"}
+      {:ja_serializer, "~> x.x.x"}
     # ...
   ]
 end


### PR DESCRIPTION
As an elixir package maintainer I'm usually forgetting to update package version at README.md. So, please save tons of time to other developers by allow them to find their version by themselves ;)