### PR TITLE
Changes

### DIFF
--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -6,8 +6,11 @@ defmodule JaSerializer.Builder.Relationship do
 
   defstruct [:name, :links, :data, :meta]
 
-  def build(%{serializer: serializer, data: data, conn: conn} = context) do
-    Enum.map serializer.relationships(data, conn), &(build(&1, context))
+  def build(%{serializer: serializer, data: data, conn: conn, opts: opts} = context) do
+    case opts[:relationships] do
+      false -> []
+      _ -> Enum.map serializer.relationships(data, conn), &(build(&1, context))
+    end
   end
 
   def build({name, definition}, context) do

--- a/lib/ja_serializer/error_serializer.ex
+++ b/lib/ja_serializer/error_serializer.ex
@@ -28,5 +28,5 @@ defmodule JaSerializer.ErrorSerializer do
     Dict.take(error, @error_fields)
   end
 
-  defp as_json(errors), do: %{errors: errors}
+  defp as_json(errors), do: %{"errors" => errors}
 end

--- a/lib/ja_serializer/formatter/relationship.ex
+++ b/lib/ja_serializer/formatter/relationship.ex
@@ -4,7 +4,7 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.Relationship do
   def format(rel) do
     json = %{}
     |> Utils.add_data_if_present(JaSerializer.Formatter.format(rel.data))
-    |> Utils.put_if_present(:links, Utils.array_to_hash(rel.links))
+    |> Utils.put_if_present("links", Utils.array_to_hash(rel.links))
     {Utils.format_key(rel.name), json}
   end
 end

--- a/lib/ja_serializer/formatter/resource.ex
+++ b/lib/ja_serializer/formatter/resource.ex
@@ -6,14 +6,14 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.ResourceObject do
     links = Utils.array_to_hash(resource.links)
 
     json = %{
-      id:            to_string(resource.id),
-      type:          resource.type,
-      attributes:    Utils.array_to_hash(resource.attributes),
+      "id"         => to_string(resource.id),
+      "type"       => resource.type,
+      "attributes" => Utils.array_to_hash(resource.attributes),
     }
 
     json
-    |> Utils.put_if_present(:relationships, relationships)
-    |> Utils.put_if_present(:links, links)
-    |> Utils.put_if_present(:meta, JaSerializer.Formatter.format(resource.meta))
+    |> Utils.put_if_present("relationships", relationships)
+    |> Utils.put_if_present("links", links)
+    |> Utils.put_if_present("meta", JaSerializer.Formatter.format(resource.meta))
   end
 end

--- a/lib/ja_serializer/formatter/resource_identifier.ex
+++ b/lib/ja_serializer/formatter/resource_identifier.ex
@@ -1,8 +1,8 @@
 defimpl JaSerializer.Formatter, for: JaSerializer.Builder.ResourceIdentifier do
   def format(resource) do
     %{
-      id:   to_string(resource.id),
-      type: resource.type
+      "id"   => to_string(resource.id),
+      "type" => resource.type
     }
   end
 end

--- a/lib/ja_serializer/formatter/top_level.ex
+++ b/lib/ja_serializer/formatter/top_level.ex
@@ -2,11 +2,11 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.TopLevel do
   alias JaSerializer.Formatter.Utils
 
   def format(struct) do
-    %{jsonapi: %{version: "1.0"}}
-    |> Map.put(:data, JaSerializer.Formatter.format(struct.data))
+    %{"jsonapi" =>  %{"version" => "1.0"}}
+    |> Map.put("data", JaSerializer.Formatter.format(struct.data))
     |> format_links(struct.links)
-    |> Utils.put_if_present(:meta, JaSerializer.Formatter.format(struct.meta))
-    |> Utils.put_if_present(:included, JaSerializer.Formatter.format(struct.included))
+    |> Utils.put_if_present("meta", JaSerializer.Formatter.format(struct.meta))
+    |> Utils.put_if_present("included", JaSerializer.Formatter.format(struct.included))
   end
 
   defp format_links(resource, nil), do: resource
@@ -15,6 +15,6 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.TopLevel do
   defp format_links(resource, links) do
     links = JaSerializer.Formatter.format(links)
             |> Enum.into(%{})
-    Map.put(resource, :links, links)
+    Map.put(resource, "links", links)
   end
 end

--- a/lib/ja_serializer/formatter/utils.ex
+++ b/lib/ja_serializer/formatter/utils.ex
@@ -9,9 +9,9 @@ defmodule JaSerializer.Formatter.Utils do
   def put_if_present(dict, key, val), do: Dict.put(dict, key, val)
 
   @doc false
-  def add_data_if_present(dict, :empty_relationship), do: Dict.put(dict, :data, nil)
-  def add_data_if_present(dict, [:empty_relationship]), do: Dict.put(dict, :data, [])
-  def add_data_if_present(dict, val), do: put_if_present(dict, :data, val)
+  def add_data_if_present(dict, :empty_relationship), do: Dict.put(dict, "data", nil)
+  def add_data_if_present(dict, [:empty_relationship]), do: Dict.put(dict, "data", [])
+  def add_data_if_present(dict, val), do: put_if_present(dict, "data", val)
 
   @doc false
   def array_to_hash(nil),   do: nil

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -89,8 +89,8 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1)
-    assert %{} = json[:data]
-    assert [_,_,_,_] = json[:included]
+    assert %{} = json["data"]
+    assert [_, _, _, _] = json["included"]
   end
 
   test "duplicate models are not included twice" do
@@ -111,8 +111,8 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1)
-    assert %{} = json[:data]
-    assert [_,_,_] = json[:included]
+    assert %{} = json["data"]
+    assert [_, _, _] = json["included"]
   end
 
   test "specifying a serializer as the `include` option still works" do
@@ -129,8 +129,8 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1)
-    assert %{} = json[:data]
-    assert [_] = json[:included]
+    assert %{} = json["data"]
+    assert [_] = json["included"]
   end
 
   # Optional includes
@@ -153,11 +153,11 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "author")
-    assert %{} = json[:data]
-    assert [_] = json[:included]
+    assert %{} = json["data"]
+    assert [_] = json["included"]
 
-    assert [%{id: "t1", type: "tags"}] == json[:data][:relationships]["tags"][:data]
-    refute json[:data][:relationships]["comments"][:data]
+    assert [%{"id" => "t1", "type" => "tags"}] == json["data"]["relationships"]["tags"]["data"]
+    refute json["data"]["relationships"]["comments"]["data"]
   end
 
   test "2nd level includes are serialized correctly" do
@@ -173,7 +173,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
     ids = Enum.map(includes, &(&1.id))
-    assert [_,_,_,_] = ids
+    assert [_, _, _, _] = ids
     assert "p1" in ids
     assert "p2" in ids
     assert "c1" in ids
@@ -181,8 +181,8 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "author,comments.author")
-    assert %{} = json[:data]
-    assert [_,_,_,_] = json[:included]
+    assert %{} = json["data"]
+    assert [_, _, _, _] = json["included"]
   end
 
   test "sibling includes are serialized correctly" do
@@ -198,7 +198,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
     ids = Enum.map(includes, &(&1.id))
-    assert [_,_,_,_] = ids
+    assert [_, _, _, _] = ids
     assert "p1" in ids
     assert "c1" in ids
     assert "t1" in ids
@@ -206,8 +206,8 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "tags,comments.author,comments.tags")
-    assert %{} = json[:data]
-    assert [_,_,_,_] = json[:included]
+    assert %{} = json["data"]
+    assert [_, _, _, _] = json["included"]
   end
 
   test "sparse fieldset returns only specified fields" do
@@ -228,14 +228,14 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1, %{}, fields: fields)
-    assert %{attributes: formatted_attrs} = json[:data]
+    assert %{"attributes" => formatted_attrs} = json["data"]
     article_attrs = Map.keys(formatted_attrs)
     assert [_] = article_attrs
     assert "title" in article_attrs
     refute "body" in article_attrs
 
-    assert [formatted_person] = json[:included]
-    person_attrs = Map.keys(formatted_person[:attributes])
+    assert [formatted_person] = json["included"]
+    person_attrs = Map.keys(formatted_person["attributes"])
     assert [_] = person_attrs
     assert "first-name" in person_attrs
     refute "last-name" in person_attrs
@@ -256,8 +256,8 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1, %{}, fields: fields)
-    assert [formatted_person] = json[:included]
-    person_attrs = Map.keys(formatted_person[:attributes])
+    assert [formatted_person] = json["included"]
+    person_attrs = Map.keys(formatted_person["attributes"])
     assert [_,_] = person_attrs
     assert "first-name" in person_attrs
     assert "last-name" in person_attrs

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -55,27 +55,27 @@ defmodule JaSerializer.Builder.RelationshipTest do
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1)
-    assert %{relationships: %{"comments" => comments}} = json[:data]
-    assert [_,_] = comments[:data]
+    assert %{"relationships" => %{"comments" => comments}} = json["data"]
+    assert [_, _] = comments["data"]
 
-    formatted_ids = Enum.map(comments[:data], &(&1.id))
+    formatted_ids = Enum.map(comments["data"], &(&1["id"]))
     assert "c1" in formatted_ids
     assert "c2" in formatted_ids
   end
 
   test "building a self link Relationship is possible along with the 'related'" do
     json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1})
-    rel_links = json.data.relationships["bars"].links
+    rel_links = json["data"]["relationships"]["bars"]["links"]
     assert  "/foo/1/relationships/bars" = rel_links["self"]
     assert  "/foo/1/bars" = rel_links["related"]
   end
 
   test "building relationships from ids works" do
     json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1})
-    assert %{relationships: %{"bars" => bars, "baz" => baz}} = json[:data]
-    assert baz.data.id == "1"
-    assert [bar, _, _ ] = bars.data
-    assert bar.id == "1"
+    assert %{"relationships" => %{"bars" => bars, "baz" => baz}} = json["data"]
+    assert baz["data"]["id"] == "1"
+    assert [bar, _, _ ] = bars["data"]
+    assert bar["id"] == "1"
   end
 
   test "identifiers are included if type passed in" do
@@ -128,6 +128,7 @@ defmodule JaSerializer.Builder.RelationshipTest do
     }
     context = %{conn: %{}, opts: [include: [:author]]}
     rel = Relationship.build({:comments, comments}, context)
+    assert is_nil(rel.data)
   end
 
   test "identifiers are not included if the serializer is passed in, there are not in include params & indentifiers is when_included" do
@@ -138,5 +139,10 @@ defmodule JaSerializer.Builder.RelationshipTest do
     context = %{conn: %{}, opts: []}
     rel = Relationship.build({:comments, comments}, context)
     assert rel.data == nil
+  end
+
+  test "skipping relationship building with `relationships: false`" do
+    json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1}, %{}, relationships: false)
+    refute Map.has_key?(json["data"], "relationships")
   end
 end

--- a/test/ja_serializer/builder/resource_object_test.exs
+++ b/test/ja_serializer/builder/resource_object_test.exs
@@ -20,7 +20,7 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1)
 
-    assert %{attributes: attributes} = json[:data]
+    assert %{"attributes" => attributes} = json["data"]
     fields = Map.keys(attributes)
     assert "title" in fields
     assert "body" in fields
@@ -39,7 +39,7 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1, %{}, fields: fields)
 
-    assert %{attributes: attributes} = json[:data]
+    assert %{"attributes" => attributes} = json["data"]
     fields = Map.keys(attributes)
     assert "title" in fields
     refute "body" in fields

--- a/test/ja_serializer/dynamic_type_test.exs
+++ b/test/ja_serializer/dynamic_type_test.exs
@@ -23,23 +23,23 @@ defmodule JaSerializer.DynamicTypeTest do
 
   test "dynamically assigns the type for single item" do
     wilbur = JaSerializer.format(AnimalSerializer, @wilbur)
-    assert wilbur.data.type == "pig"
+    assert wilbur["data"]["type"] == "pig"
   end
 
   test "works for multiple items" do
     animals = JaSerializer.format(AnimalSerializer, [@wilbur, @charlotte])
-    assert animals.data |> Enum.map(&(&1.type)) == ~w(pig spider)
+    assert animals["data"] |> Enum.map(&(&1["type"])) == ~w(pig spider)
   end
 
   test "works with 'has_many' relationship data" do
     farm = JaSerializer.format(FarmSerializer, @farm)
-    animals = farm.data.relationships["animals"].data |> Enum.map(&(&1.type))
+    animals = farm["data"]["relationships"]["animals"]["data"] |> Enum.map(&(&1["type"]))
     assert "pig" in animals
     assert "spider" in animals
   end
 
   test "works with 'has_one' relationship data" do
     farm = JaSerializer.format(FarmSerializer, @farm)
-    assert farm.data.relationships["special-animal"].data.type == "pig"
+    assert farm["data"]["relationships"]["special-animal"]["data"]["type"] == "pig"
   end
 end

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -5,7 +5,7 @@ defmodule JaSerializer.EctoErrorSerializerTest do
 
   test "Will correctly format a changeset with an error" do
     expected = %{
-      errors: [
+      "errors" => [
         %{
           source: %{pointer: "/data/attributes/title"},
           title: "is invalid",
@@ -21,7 +21,7 @@ defmodule JaSerializer.EctoErrorSerializerTest do
 
   test "Will correctly format a changeset with a count error" do
     expected = %{
-      errors: [
+      "errors" => [
         %{
           source: %{pointer: "/data/attributes/monies"},
           title: "must be more then 10",
@@ -42,7 +42,7 @@ defmodule JaSerializer.EctoErrorSerializerTest do
 
   test "Will correctly format a changeset with multiple errors on one attribute" do
     expected = %{
-      errors: [
+      "errors" => [
         %{
           source: %{pointer: "/data/attributes/title"},
           title: "shouldn't be blank",

--- a/test/ja_serializer/error_serializer_test.exs
+++ b/test/ja_serializer/error_serializer_test.exs
@@ -4,13 +4,13 @@ defmodule JaSerializer.ErrorSerializerTest do
   alias JaSerializer.ErrorSerializer
 
   test "formatting one error" do
-    expected = %{errors: [%{ title: "foo", detail: "bar"}]}
+    expected = %{"errors" => [%{ title: "foo", detail: "bar"}]}
     assert expected == ErrorSerializer.format(%{title: "foo", detail: "bar"})
   end
 
   test "formatting a list of errors" do
     expected = %{
-      errors: [
+      "errors" => [
         %{title: "foo", detail: "baz"},
         %{title: "fu", detail: "bar"}
       ]
@@ -22,7 +22,7 @@ defmodule JaSerializer.ErrorSerializerTest do
   end
 
   test "ignore invalid fields" do
-    expected = %{errors: [%{title: "foo"}]}
+    expected = %{"errors" => [%{title: "foo"}]}
     assert expected == ErrorSerializer.format(%{title: "foo", name: "bar"})
   end
 end

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -21,69 +21,69 @@ defmodule JaSerializer.PhoenixViewTest do
 
   test "render conn, index.json-api, data: data", c do
     json = @view.render("index.json-api", conn: %{}, data: [c[:m1], c[:m2]])
-    assert [a1, _a2] = json[:data]
-    assert Dict.has_key?(a1, :id)
-    assert Dict.has_key?(a1, :attributes)
+    assert [a1, _a2] = json["data"]
+    assert Dict.has_key?(a1, "id")
+    assert Dict.has_key?(a1, "attributes")
   end
 
   # This should be deprecated in the future
   test "render conn, index.json, data: data", c do
     json = @view.render("index.json", conn: %{}, data: [c[:m1], c[:m2]])
-    assert [a1, _a2] = json[:data]
-    assert Dict.has_key?(a1, :id)
-    assert Dict.has_key?(a1, :attributes)
+    assert [a1, _a2] = json["data"]
+    assert Dict.has_key?(a1, "id")
+    assert Dict.has_key?(a1, "attributes")
   end
 
   test "render conn, index.json-api, articles: models", c do
     json = @view.render("index.json-api", conn: %{}, articles: [c[:m1], c[:m2]])
-    assert [a1, _a2] = json[:data]
-    assert Dict.has_key?(a1, :id)
-    assert Dict.has_key?(a1, :attributes)
+    assert [a1, _a2] = json["data"]
+    assert Dict.has_key?(a1, "id")
+    assert Dict.has_key?(a1, "attributes")
   end
 
   test "render conn, index.json-api, model: model with custom pagination", c do
-    json = @view.render("index.json-api", conn: %{}, model: [c[:m1], c[:m2]],
+    json = @view.render("index.json-api", conn: %{}, data: [c[:m1], c[:m2]],
       opts: [page: [first: "/v1/posts/foo"]])
-    assert [a1, _a2] = json[:data]
-    assert Dict.has_key?(a1, :id)
-    assert Dict.has_key?(a1, :attributes)
-    assert Dict.has_key?(json, :links)
+    assert [a1, _a2] = json["data"]
+    assert Dict.has_key?(a1, "id")
+    assert Dict.has_key?(a1, "attributes")
+    assert Dict.has_key?(json, "links")
   end
 
   test "render conn, index.json-api, model: model with scrivener pagination", c do
     model = %Scrivener.Page{entries: [c[:m1], c[:m2]], page_number: 1}
     conn = %Plug.Conn{query_params: %{}}
-    json = @view.render("index.json-api", conn: conn, model: model)
-    assert [a1, _a2] = json[:data]
-    assert Dict.has_key?(a1, :id)
-    assert Dict.has_key?(a1, :attributes)
-    assert Dict.has_key?(json, :links)
+    json = @view.render("index.json-api", conn: conn, data: model)
+    assert [a1, _a2] = json["data"]
+    assert Dict.has_key?(a1, "id")
+    assert Dict.has_key?(a1, "attributes")
+    assert Dict.has_key?(json, "links")
   end
 
   test "render conn, show.json-api, data: model", c do
     json = @view.render("show.json-api", conn: %{}, data: c[:m1])
-    assert Dict.has_key?(json[:data], :id)
-    assert Dict.has_key?(json[:data], :attributes)
+    assert Dict.has_key?(json["data"], "id")
+    assert Dict.has_key?(json["data"], "attributes")
   end
 
   # This should be deprecated in the future
   test "render conn, show.json, data: model", c do
     json = @view.render("show.json", conn: %{}, data: c[:m1])
-    assert Dict.has_key?(json[:data], :id)
-    assert Dict.has_key?(json[:data], :attributes)
+    assert Dict.has_key?(json["data"], "id")
+    assert Dict.has_key?(json["data"], "attributes")
   end
 
   test "render conn, show.json-api, article: model", c do
     json = @view.render("show.json-api", conn: %{}, article: c[:m1])
-    assert Dict.has_key?(json[:data], :id)
-    assert Dict.has_key?(json[:data], :attributes)
+    assert Dict.has_key?(json["data"], "id")
+    assert Dict.has_key?(json["data"], "attributes")
   end
 
   test "render conn, 'errors.json-api', data: changeset" do
     errors = Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid")
     json = @view.render("errors.json-api", conn: %{}, data: errors)
-    assert Dict.has_key?(json, :errors)
-    assert [e1] = json[:errors]
+    assert Dict.has_key?(json, "errors")
+    assert [e1] = json["errors"]
     assert e1.source.pointer == "/data/attributes/title"
     assert e1.detail == "Title is invalid"
   end


### PR DESCRIPTION
Please consider this a WIP branch. It does address #143 as well as some other blockers I've hit.

The 2nd change may appear to be subjective but I'd like to discuss the merits of it before any rejection is given.

1. Added `bare: true` to allow `JaSerializer.Builder.ResourceObject` to
build a bare object without requiring relationships. This can probably
be expected to `meta` and `links` as well. TBD.
2. Changed `JaSerializer.Formatter` to always output all keys as
strings. Currently the output format was a mix of atoms and strings.
Having a consistent key format will make payloads easier to test.
However, this may have an impact on the performance of the library and
this should be considered a breaking API change.