### PR TITLE
Deep merge relationship paths

### DIFF
--- a/lib/ja_serializer/builder/top_level.ex
+++ b/lib/ja_serializer/builder/top_level.ex
@@ -69,7 +69,7 @@ defmodule JaSerializer.Builder.TopLevel do
     normalized = path
     |> String.split(".")
     |> normalize_relationship_path
-    |> Keyword.merge(normalized, fn(_k, v1, v2) -> v1 ++ v2 end)
+    |> deep_merge_relationship_paths(normalized)
 
     normalize_relationship_path_list(paths, normalized)
   end
@@ -78,6 +78,9 @@ defmodule JaSerializer.Builder.TopLevel do
   defp normalize_relationship_path([rel_name | remaining]) do
     Keyword.put([], String.to_atom(rel_name), normalize_relationship_path(remaining))
   end
+
+  defp deep_merge_relationship_paths(left, right), do: Keyword.merge(left, right, &deep_merge_relationship_paths/3)
+  defp deep_merge_relationship_paths(_key, left, right), do: deep_merge_relationship_paths(left, right)
 
   defp add_meta(tl, nil), do: tl
   defp add_meta(tl, %{} = meta), do: Map.put(tl, :meta, meta)


### PR DESCRIPTION
Fixes #150

Keyword.merge was concatenating the nested lists instead of recursively merging the lists, so that relationships paths that shared relationships past the first level were never merged.  This then left the Keyword list with multiple copies of the same key and last code line Included.build only saw the first copy of the key (which was actually the last path in the string format because of the prepending to the normalized relationship path list).