### PR TITLE
Changed parse_realtionships function for current work with a nil realtionship

### DIFF
--- a/lib/ja_serializer/params.ex
+++ b/lib/ja_serializer/params.ex
@@ -57,7 +57,8 @@ defmodule JaSerializer.Params do
 
   defp parse_relationships(%{"relationships" => rels}) do
     Enum.reduce rels, %{}, fn
-      ({_name, %{"data" => nil}}, rel) -> rel
+      ({name, %{"data" => nil}}, rel) ->
+        Map.put(rel, "#{name}_id", nil)
       ({name, %{"data" => %{"id" => id}}}, rel) ->
         Map.put(rel, "#{name}_id", id)
       ({name, %{"data" => ids}}, rel) when is_list(ids) ->

--- a/test/ja_serializer/params_test.exs
+++ b/test/ja_serializer/params_test.exs
@@ -31,6 +31,21 @@ defmodule JaSerializer.ParamsTest do
     assert to_attributes(input) == output
   end
 
+  test "nil relationship" do
+    input = %{"data" => %{
+      "type" => "person",
+      "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
+      "relationships" => %{"user" => %{"data" => nil}}
+    }}
+    output = %{
+      "first" => "Jane",
+      "last" => "Doe",
+      "type" => "anon",
+      "user_id" => nil
+    }
+    assert to_attributes(input) == output
+  end
+
   test "plural relationships" do
     input = %{"data" => %{
       "type" => "person",


### PR DESCRIPTION
Hello.

When I change a realtionship id from null to 1 or from 1 to 2 it work as expected. But when I change a realtionship id from 1 to null, it work wrong - a nullable variable is excluded from a changes field in result changeset and misses in SQL query.
