### PR TITLE
Support additional error fields in EctoErrorSerializer

### DIFF
--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -63,4 +63,26 @@ defmodule JaSerializer.EctoErrorSerializerTest do
     assert expected == EctoErrorSerializer.format(changeset)
   end
 
+  test "Support additional fields per the JSONAPI standard" do
+    expected = %{
+      "errors" => [
+      %{
+        id: "1",
+        status: "422",
+        code: "1000",
+        title: "is invalid",
+        detail: "Title is invalid",
+        source: %{pointer: "/data/attributes/title"},
+        links: %{self: "http://localhost"},
+        meta: %{author: "Johnny"}
+      }
+    ]
+    }
+
+    assert expected == EctoErrorSerializer.format(
+      Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid"), %{},
+      opts: [id: "1", status: "422", code: "1000", links: %{self: "http://localhost"}, meta: %{author: "Johnny"}]
+    )
+  end
+
 end


### PR DESCRIPTION
Passing options for additional error fields was not actually including those fields
in the error object returned. This fixes that and now the error object can include
the additional errors.

I've also included some documentation for the module. 