### PR TITLE
The example pagination links in the README (pasted below) fail due to…

### DIFF
--- a/lib/ja_serializer/formatter/top_level.ex
+++ b/lib/ja_serializer/formatter/top_level.ex
@@ -14,6 +14,7 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.TopLevel do
 
   defp format_links(resource, links) do
     links = JaSerializer.Formatter.format(links)
+            |> Enum.reject(&(is_nil(&1)))
             |> Enum.into(%{})
     Map.put(resource, "links", links)
   end


### PR DESCRIPTION
… the nil link and this is an attempt to fix that.

page = [
      first: "http://example.com/api/v1/posts?page[cursor]=1&page[per]=20",
      prev: nil,
      next: "http://example.com/api/v1/posts?page[cursor]=20&page[per]=20",
      last: "http://example.com/api/v1/posts?page[cursor]=60&page[per]=20"
    ]