### PR TITLE
Fix crashes that occur when using custom pagination links

### DIFF
--- a/lib/ja_serializer/builder/link.ex
+++ b/lib/ja_serializer/builder/link.ex
@@ -27,6 +27,25 @@ defmodule JaSerializer.Builder.Link do
   end
 
   defp path_for_context(context, path) do
+    uri = URI.parse(path)
+    path = uri
+    |> Map.put(:path, replaced_path_for_context(context, uri.path))
+    |> Map.put(:query, replaced_path_for_context(context, uri.query))
+    |> URI.to_string
+
+    # Remove trailing question mark if there is no query string.
+    # A query string itself can contain a trailing question mark so we only
+    # do this if URI did not parse out a query.
+    if nil == uri.query do
+      Regex.replace ~r/\?$/, path, ""
+    else
+      path
+    end
+  end
+
+  defp replaced_path_for_context(context, nil), do: ""
+
+  defp replaced_path_for_context(context, path) do
     @param_fetcher_regex
     |> Regex.replace(path, &frag_for_context(&1, context))
   end

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -50,6 +50,15 @@ defmodule JaSerializer.PhoenixViewTest do
     assert Dict.has_key?(json, "links")
   end
 
+  test "render conn, index.json-api, model: model with custom pagination using urls with ports", c do
+    json = @view.render("index.json-api", conn: %{}, data: [c[:m1], c[:m2]],
+      opts: [page: [first: "http://localhost:4000/v1/posts/foo"]])
+    assert [a1, _a2] = json["data"]
+    assert Dict.has_key?(a1, "id")
+    assert Dict.has_key?(a1, "attributes")
+    assert Dict.has_key?(json, "links")
+  end
+
   test "render conn, index.json-api, model: model with scrivener pagination", c do
     model = %Scrivener.Page{entries: [c[:m1], c[:m2]], page_number: 1}
     conn = %Plug.Conn{query_params: %{}}


### PR DESCRIPTION
containing a port number. 

The colon used for the port conflicts with param_fetcher_regex and the 'param' that is actually fetched in this case is the port. To get around this, I URI.parse the link. If it doesn't contain a port,
I let the existing implementation run. If it does, then I pass just the relative path portion of the link to the existing logic and with the result reassemble the fully qualified url.