### PR TITLE
Fix Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ defmodule MyApp.ArticleSerializer do
     Comment.for_article(article)
   end
 
-  def excerpt(article, _conn) do
+  def except(article, _conn) do
     [first | _ ] = String.split(article.body, ".")
     first
   end


### PR DESCRIPTION
Minor typo in README fixed `excerpt` -> `except`